### PR TITLE
test: add worker helper unit suite

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -70,11 +70,11 @@ async function getToday(bucket: R2Bucket): Promise<string> {
   return data.date;
 }
 
-function isProgressive(url: URL): boolean {
+export function isProgressive(url: URL): boolean {
   return url.searchParams.get("progressive") === "true";
 }
 
-function isStrip(url: URL): boolean {
+export function isStrip(url: URL): boolean {
   return url.searchParams.get("strip") === "true";
 }
 
@@ -93,9 +93,10 @@ const TELEMETRY_BODY_LIMIT = 4096;
 const TELEMETRY_ORIGINS_DEFAULT =
   "https://kevintcoughlin.com,https://www.kevintcoughlin.com";
 
-function getAllowedOrigins(env: Env): Set<string> {
-  const raw = env.ALLOWED_ORIGINS ?? TELEMETRY_ORIGINS_DEFAULT;
-  return new Set(raw.split(",").map((s) => s.trim()).filter(Boolean));
+export function getAllowedOrigins(env: Env): Set<string> {
+  const raw = (env.ALLOWED_ORIGINS ?? TELEMETRY_ORIGINS_DEFAULT).trim();
+  const value = raw || TELEMETRY_ORIGINS_DEFAULT;
+  return new Set(value.split(",").map((s) => s.trim()).filter(Boolean));
 }
 
 function telemetryCorsHeaders(origin: string): Record<string, string> {
@@ -106,7 +107,7 @@ function telemetryCorsHeaders(origin: string): Record<string, string> {
   };
 }
 
-function classifyUA(ua: string): "mobile" | "desktop" {
+export function classifyUA(ua: string): "mobile" | "desktop" {
   return /Mobile|Android|iPhone|iPad/i.test(ua) ? "mobile" : "desktop";
 }
 

--- a/worker/test/unit-helpers.test.ts
+++ b/worker/test/unit-helpers.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyUA, getAllowedOrigins, isProgressive, isStrip } from "../src/index";
+
+describe("worker helper utilities", () => {
+  it("detects mobile user agents", () => {
+    expect(classifyUA("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)")).toBe("mobile");
+    expect(classifyUA("Mozilla/5.0 (Linux; Android 14; Pixel 8)")).toBe("mobile");
+  });
+
+  it("detects desktop user agents", () => {
+    expect(classifyUA("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36")).toBe("desktop");
+    expect(classifyUA("Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5)")).toBe("desktop");
+  });
+
+  it("parses progressive and strip query flags", () => {
+    expect(isProgressive(new URL("https://example.com/api/today?progressive=true"))).toBe(true);
+    expect(isProgressive(new URL("https://example.com/api/today"))).toBe(false);
+    expect(isStrip(new URL("https://example.com/api/today?strip=true"))).toBe(true);
+    expect(isStrip(new URL("https://example.com/api/today"))).toBe(false);
+  });
+
+  it("uses configured allowed origins and trims whitespace", () => {
+    const env = {
+      ALLOWED_ORIGINS: "https://example.com, https://cdn.example.com , https://api.example.com",
+    } as Parameters<typeof getAllowedOrigins>[0];
+
+    expect([...getAllowedOrigins(env)]).toEqual([
+      "https://example.com",
+      "https://cdn.example.com",
+      "https://api.example.com",
+    ]);
+  });
+
+  it("falls back to the default allowed origins when none are configured", () => {
+    const env = { ALLOWED_ORIGINS: "" } as Parameters<typeof getAllowedOrigins>[0];
+
+    expect([...getAllowedOrigins(env)]).toEqual([
+      "https://kevintcoughlin.com",
+      "https://www.kevintcoughlin.com",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a new worker-side unit test suite for helper utilities
- export pure helpers to make them directly testable
- harden allowed-origin parsing to fall back to the default origins when unset or empty

## Testing
- npm test
- uv run pytest