### PR TITLE
Fix invalid workflow syntax halting daily art generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # An invalid workflow file does not fail any PR check — GitHub simply
+  # refuses to run it, and scheduled runs stop being created silently.
+  # This job turns that failure mode into a red check.
+  actionlint:
+    name: Workflow lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      ACTIONLINT_VERSION: 1.7.7
+      ACTIONLINT_SHA256: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install actionlint
+        run: |
+          curl -sSfL -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum --check --strict
+          tar xzf actionlint.tar.gz actionlint
+
+      - name: Lint workflows
+        run: ./actionlint -color
+
   python:
     name: Python (${{ matrix.os }}, ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/generate-self-hosted.yml
+++ b/.github/workflows/generate-self-hosted.yml
@@ -18,6 +18,10 @@ jobs:
       # Persistent directories on the Mac Mini avoid re-downloading each run.
       UV_CACHE_DIR: ~/Library/Caches/bauhaus-uv
       MODELS_CACHE: models/weights
+      # The `secrets` context is not available in step-level `if:` conditions,
+      # but `env` is — so gate values must be surfaced here.
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
     steps:
       - uses: actions/checkout@v7
 
@@ -38,9 +42,8 @@ jobs:
         run: python models/download_models.py
 
       - name: Import GPG key
-        if: ${{ secrets.GPG_PRIVATE_KEY != '' }}
+        if: env.GPG_PRIVATE_KEY != ''
         env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           echo "$GPG_PRIVATE_KEY" | gpg --batch --import
@@ -70,8 +73,6 @@ jobs:
             -H "Actions: view, Open Run, ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             -d "Self-hosted generate completed successfully." \
             "https://ntfy.sh/$NTFY_TOPIC"
-        env:
-          NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
 
       - name: Notify failure
         if: failure() && env.NTFY_TOPIC != ''
@@ -84,5 +85,3 @@ jobs:
             -H "Actions: view, Open Run, ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             -d "Self-hosted generate failed. Check the run logs." \
             "https://ntfy.sh/$NTFY_TOPIC"
-        env:
-          NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   generate:
     runs-on: ubuntu-latest
+    # Job-level env: the `secrets` context is not available in step-level `if:`
+    # conditions, but `env` is — so gate values must be surfaced here.
+    env:
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
     steps:
       - uses: actions/checkout@v7
 
@@ -36,9 +41,8 @@ jobs:
         run: python models/download_models.py
 
       - name: Import GPG key
-        if: ${{ secrets.GPG_PRIVATE_KEY != '' }}
+        if: env.GPG_PRIVATE_KEY != ''
         env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           echo "$GPG_PRIVATE_KEY" | gpg --batch --import
@@ -71,8 +75,6 @@ jobs:
             -H "Actions: view, Open Run, ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             -d "Generate workflow completed successfully." \
             "https://ntfy.sh/$NTFY_TOPIC"
-        env:
-          NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
 
       - name: Notify failure
         if: failure() && env.NTFY_TOPIC != ''
@@ -85,5 +87,3 @@ jobs:
             -H "Actions: view, Open Run, ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             -d "Generate workflow failed. Check the run logs for details." \
             "https://ntfy.sh/$NTFY_TOPIC"
-        env:
-          NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}


### PR DESCRIPTION
## Summary

**The daily art pipeline has not run since 2026-07-19.** Both generate workflows have been failing GitHub's workflow validation for 12 days, so no new art has been generated or uploaded to R2.

## Root cause

PR #46 ("Add PGP metadata signing") added an `Import GPG key` step to `generate.yml` and `generate-self-hosted.yml` gated on:

```yaml
if: ${{ secrets.GPG_PRIVATE_KEY != '' }}
```

The `secrets` context is **not available in step-level `if:` conditions**. This makes the whole workflow file invalid, so GitHub rejects each run before scheduling any job — and stops creating scheduled runs altogether.

Evidence:

- Last successful scheduled run: `2026-07-19T05:02:51Z`. #46 merged the next day (`2026-07-20T05:04Z`), and there have been **no scheduled runs since**.
- Every run after the merge has `total_count: 0` jobs, with `created_at == run_started_at == updated_at` to the second — the signature of a rejected workflow file, not a runtime failure.
- `actionlint` flags exactly these two lines: `context "secrets" is not allowed here`.

## Why it went unnoticed for 12 days

Two compounding reasons.

**1. The alerting was broken by the same class of bug.** The ntfy notification steps read:

```yaml
- name: Notify failure
  if: failure() && env.NTFY_TOPIC != ''
  env:
    NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
```

Step conditions are evaluated against **job-level** env, not the step's own `env:` block, so `env.NTFY_TOPIC` was always empty and the notify steps could never fire.

**2. An invalid workflow file fails no PR check.** GitHub just refuses to run it. Nothing in CI went red, so there was no signal anywhere.

## Changes

**Fix the outage**
- Surface `GPG_PRIVATE_KEY` and `NTFY_TOPIC` as **job-level** `env`, which *is* available to step conditionals.
- Gate the GPG step on `if: env.GPG_PRIVATE_KEY != ''`.
- Drop the now-redundant step-level `NTFY_TOPIC` / `GPG_PRIVATE_KEY` entries.
- Applied identically to `generate.yml` and `generate-self-hosted.yml`.

**Prevent a recurrence**
- Add an `actionlint` job to `ci.yml` so a malformed workflow fails a PR check instead of silently disabling the pipeline. The release is pinned and checksum-verified before execution.

Signing remains fully optional — `sign_metadata()` returns `None` and the pipeline continues when GPG is unconfigured, so the gate is safe either way.

## Verification

- `actionlint` clean on all five workflows (was: 2 errors), including with `shellcheck` on PATH to match the runner environment — so the new job passes against the current tree.
- **Guardrail regression-tested:** reintroducing `if: ${{ secrets.GPG_PRIVATE_KEY != '' }}` makes the lint job exit 1. It catches the exact defect that caused this outage.
- `pytest`: 186 passed locally; full CI green on the first commit (8/8 jobs).
- The push to this branch produced **no** invalid-workflow failure record, unlike every dependabot push before it — independent confirmation the file now parses.

## After merge

The 4 AM UTC schedule resumes on its own, but it needs one manual `workflow_dispatch` of *Generate Daily Art* to backfill the gap. I'll trigger that once this is merged.

Note: I was unable to verify the live CDN directly — this environment's network policy blocks `bauhaus.cascadiacollections.workers.dev`. The staleness claim is inferred from pipeline history, not observed at the edge.