### PR TITLE
perf(docker): drop UV_COMPILE_BYTECODE, keep uv off managed interpreters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,16 @@ FROM python:3.14-slim
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-# Bytecode-compile on install so the first run doesn't pay for it, and copy
-# rather than hardlink since the cache and the venv are on different layers.
-ENV UV_COMPILE_BYTECODE=1 \
-    UV_LINK_MODE=copy
+# Copy rather than hardlink, since the cache and the venv land on different
+# layers. Deliberately NOT setting UV_COMPILE_BYTECODE: this image runs one
+# batch generation and exits, so shaving import time off a process that then
+# spends minutes in style transfer does not repay compiling all of torch on
+# every build.
+#
+# only-system: the base image already pins the interpreter this project wants,
+# so uv should use it rather than downloading a managed CPython of its own.
+ENV UV_LINK_MODE=copy \
+    UV_PYTHON_PREFERENCE=only-system
 
 WORKDIR /app
 


### PR DESCRIPTION
A one-commit follow-up to #99. This fix was pushed a few minutes after the merge snapshot was taken, so it missed the squash — `main` still has the settings it corrects.

## Why

The Podman smoke job went from **~95 s** (on #96, before the Dockerfile changes) to **295 s** on #99's head. It passed, comfortably inside the 10-minute timeout, but the jump traces to two settings I added in #99 that don't hold up:

**`UV_COMPILE_BYTECODE=1` was cargo-culted in** as a "usual companion" setting without reasoning about this particular workload. It trades build time for interpreter start-up time — a good trade for a long-lived server. This image runs a single batch generation and exits, and that process then spends minutes in style transfer. Shaving a fraction of a second off imports doesn't repay bytecode-compiling all of torch on every build, or the image size that comes with it.

**uv's default `python-preference` is `managed`**, so `uv run --script models/download_models.py` could download a CPython of its own inside an image whose base already pins the interpreter the project asks for. `UV_PYTHON_PREFERENCE=only-system` keeps it on the one that's already there.

`UV_LINK_MODE=copy` stays — the cache and the venv genuinely land on different layers, so hardlinking is wrong here.

## Confidence

The two settings are wrong on their merits independent of the timing, which is why the change stands on its own. But the attribution of the 95 s → 295 s jump is inferred from job duration rather than read from build logs — the logs endpoint 404s while a job is in progress, and by the time it completed the PR had merged. The Podman run on this PR is what actually measures it: if the build comes back near 95 s, the attribution was right.

The two causes are also confounded with each other — this PR addresses both, so it won't separate their individual contributions. If that distinction matters, the bytecode setting is the one worth isolating.

No behaviour change to the generated output; the Podman smoke job exercises the full build-and-run path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrJ841AtThRoTsGF62vqKs)_