### PR TITLE
perf(docker): drop UV_LINK_MODE=copy — the actual cause of the slow build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,16 @@ FROM python:3.14-slim
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-# Copy rather than hardlink, since the cache and the venv land on different
-# layers. Deliberately NOT setting UV_COMPILE_BYTECODE: this image runs one
-# batch generation and exits, so shaving import time off a process that then
-# spends minutes in style transfer does not repay compiling all of torch on
-# every build.
+# Deliberately NOT setting UV_LINK_MODE=copy. The dependency set is ~5 GB of
+# CUDA wheels, and copy mode duplicates every byte of it from the uv cache into
+# .venv, so the layer stores the payload twice. That cost 196s of the 269s
+# build in #100 — the layer commit alone, measured from the build log. uv's
+# default hardlink mode is correct here: at build time the cache and the venv
+# are on one overlay filesystem, not separate ones.
 #
 # only-system: the base image already pins the interpreter this project wants,
 # so uv should use it rather than downloading a managed CPython of its own.
-ENV UV_LINK_MODE=copy \
-    UV_PYTHON_PREFERENCE=only-system
+ENV UV_PYTHON_PREFERENCE=only-system
 
 WORKDIR /app
 


### PR DESCRIPTION
**Correcting #100.** That PR removed `UV_COMPILE_BYTECODE` on the theory it caused the Podman smoke job's regression from ~95 s to ~295 s, and said explicitly that the follow-up run would settle it. It came back at **292 s** — essentially unchanged. The theory was wrong.

The build log is only fetchable once a job completes, which is why this took a second pass. It gives an unambiguous answer:

```
01:56:33  STEP 6/11: RUN uv sync --locked --no-dev
01:56:55  Prepared 43 packages in 22.83s
01:57:18  Installed 43 packages in 22.94s
02:00:34  --> ef4ab0a1f0d8
```

**196 of the 269 s build is podman committing that one layer.** Everything else is small: downloads 23 s, install 23 s, model download 7 s, container run 19 s.

## The cause

`UV_LINK_MODE=copy` — the setting #100 kept and explicitly defended.

This project pulls roughly 5 GB of CUDA wheels (torch 502 MB, cublas 403 MB, cudnn 349 MB, cufft 204 MB, nccl 196 MB, cusolver 191 MB, triton 188 MB, cusparselt 162 MB, cusparse 139 MB). Copy mode physically duplicates every byte from the uv cache into `.venv`, so the layer holds the payload twice and takes about twice as long to write.

The justification I gave for it was wrong on its own terms. "The cache and the venv land on different layers" does not imply different *filesystems* — during a build they share one overlay filesystem, so uv's default hardlink mode works and stores the payload once. `UV_LINK_MODE=copy` matters for multi-stage builds that copy a venv across a stage boundary, which this Dockerfile does not do. The ~95 s baseline had no `UV_LINK_MODE` set at all, which is exactly the state this restores.

`UV_PYTHON_PREFERENCE=only-system` stays. The log confirms it working — `Using CPython 3.14.6 interpreter at: /usr/local/bin/python3`, and the `uv run --script` model download completes in 7 s with no managed-interpreter fetch.

## What to expect

If this is right, Podman smoke returns to roughly 95 s. That is the check to watch — the same prediction #100 made and failed, so it is worth confirming rather than assuming.

A further improvement I have *not* made, to keep this change minimal and attributable: `--no-cache` on the `uv sync` would keep the uv cache out of the image entirely, shipping only the venv. That is likely a real win on image size, but it is unmeasured here and would confound this measurement.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrJ841AtThRoTsGF62vqKs)_