### PR TITLE
Fix publishing integrity, cache honesty, and dormant signing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
     },
     "ghcr.io/devcontainers/features/common-utils:2": {}
   },
-  "postCreateCommand": "cd ${containerWorkspaceFolder} && uv sync && cd worker && npm ci",
+  "postCreateCommand": "cd ${containerWorkspaceFolder} && uv sync && uv run --script models/download_models.py && cd worker && npm ci",
   "customizations": {
     "vscode": {
       "settings": {

--- a/.github/workflows/generate-self-hosted.yml
+++ b/.github/workflows/generate-self-hosted.yml
@@ -8,6 +8,12 @@ name: Generate Daily Art (Self-Hosted Mac Mini)
 # hand when you want the Mac Mini's MPS acceleration.
 on:
   workflow_dispatch:
+    inputs:
+      overwrite:
+        description: "Republish today even if it already exists (breaks immutable caches)"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -19,9 +25,10 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     timeout-minutes: 15
     env:
-      # Persistent directories on the Mac Mini avoid re-downloading each run.
-      UV_CACHE_DIR: ~/Library/Caches/bauhaus-uv
-      MODELS_CACHE: models/weights
+      # Persistent uv cache on the Mac Mini avoids re-downloading each run.
+      # $HOME rather than ~: `env:` values are not shell-expanded, so a tilde
+      # here would be taken literally and create a directory named "~".
+      UV_CACHE_DIR: ${{ github.workspace }}/../bauhaus-uv-cache
       # The `secrets` context is not available in step-level `if:` conditions,
       # but `env` is — so gate values must be surfaced here.
       GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -55,8 +62,12 @@ jobs:
 
       # CC0 museum source — see the note in generate.yml.
       - name: Generate and upload
-        run: uv run python src/main.py --source met
+        run: |
+          uv run python src/main.py --source met ${OVERWRITE:+--overwrite}
         env:
+          # Publishing is write-once, so a dispatch on a day generate.yml has
+          # already run needs this checked to proceed.
+          OVERWRITE: ${{ inputs.overwrite && '1' || '' }}
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -9,6 +9,11 @@ on:
         type: choice
         default: met
         options: [met, artic, unsplash]
+      overwrite:
+        description: "Republish today even if it already exists (breaks immutable caches)"
+        required: false
+        type: boolean
+        default: false
   schedule:
     - cron: '0 4 * * *'  # 4 AM UTC (8 PM PT prev day) — off-peak
 
@@ -43,10 +48,13 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-py3.14-${{ hashFiles('uv.lock') }}
 
+      # Keyed on the download script so that changing a pinned checksum (or the
+      # release URL) evicts weights cached under the old pins. A constant key
+      # can never invalidate, which would pin a bad cache entry forever.
       - uses: actions/cache@v6
         with:
           path: models/weights
-          key: adain-models-v1
+          key: adain-models-${{ hashFiles('models/download_models.py') }}
 
       - name: Install dependencies
         run: uv sync --frozen --no-dev
@@ -67,9 +75,13 @@ jobs:
       # available via the workflow_dispatch input (its licence is not CC0,
       # so those runs produce source-dependent output).
       - name: Generate and upload
-        run: uv run python src/main.py --source "${SOURCE}"
+        run: |
+          uv run python src/main.py --source "${SOURCE}" ${OVERWRITE:+--overwrite}
         env:
           SOURCE: ${{ inputs.source || 'met' }}
+          # Empty unless the dispatch input is checked; ${VAR:+--overwrite}
+          # then expands to nothing, so scheduled runs never pass the flag.
+          OVERWRITE: ${{ inputs.overwrite && '1' || '' }}
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/generation-benchmark.yml
+++ b/.github/workflows/generation-benchmark.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/cache@v6
         with:
           path: models/weights
-          key: adain-models-v1
+          key: adain-models-${{ hashFiles('models/download_models.py') }}
 
       - name: Install dependencies
         run: uv sync --frozen --no-dev

--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ Base URL: `https://bauhaus.cascadiacollections.workers.dev`
 | `GET /api/today.json` | Today's metadata (title, artist, source, license, variants) |
 | `GET /api/today.manifest.json` | Variant manifest (srcset / responsive helper) |
 | `GET /api/YYYY-MM-DD` | Stylized image for a specific date (content-negotiated) |
-| `GET /api/YYYY-MM-DD.avif` | Stylized image (AVIF) for a specific date |
-| `GET /api/YYYY-MM-DD.webp` | Stylized image (WebP) for a specific date |
 | `GET /api/YYYY-MM-DD/original` | Original unstylized image |
 | `GET /api/YYYY-MM-DD.json` | Metadata for a specific date |
 | `GET /api/YYYY-MM-DD.manifest.json` | Variant manifest for a specific date |
+| `GET /api/YYYY-MM-DD.json.sig` | Detached PGP signature over that date's metadata JSON (404 when signing is off) |
+| `GET /api/health` | Publish freshness for uptime monitoring — `200` when current, `503` when stale |
 | `POST /api/vitals` | Ingest Web Vitals RUM (Analytics Engine) |
 | `POST /api/err` | Ingest JS error RUM (Analytics Engine) |
 
@@ -98,8 +98,8 @@ All `GET` endpoints also support `HEAD` — returns the same response headers (i
 
 | Endpoint pattern | `Cache-Control` |
 |-----------------|----------------|
-| `/api/today*` | `public, max-age=300, s-maxage=86400, stale-while-revalidate=604800` — short browser TTL since "today" rolls over daily; CDN edge holds it for up to one day |
-| `/api/YYYY-MM-DD*` | `public, max-age=31536000, s-maxage=31536000, immutable` — date-specific content never changes |
+| `/api/today*` | `public, max-age=300, s-maxage=3600, stale-while-revalidate=604800` — short browser TTL since "today" rolls over daily; the edge TTL stays below the 24h publish interval so a PoP cannot serve yesterday's artwork past the next run |
+| `/api/YYYY-MM-DD*` | `public, max-age=31536000, s-maxage=31536000, immutable` — safe because publishing is write-once: the pipeline refuses to rewrite a date unless `--overwrite` is passed |
 
 ### Responsive image consumer snippet
 
@@ -144,13 +144,7 @@ If the preferred format is missing, it falls back to JPEG.
 
 All image responses include a `Vary: Accept` header for correct caching.
 
-The Worker uses `Accept` header content negotiation for the base image endpoints. If the client sends `Accept: image/avif`, the AVIF variant is returned (falling back to JPEG if unavailable). Explicit `.avif` and `.webp` extensions are also supported.
-
-### Query parameters
-
-| Parameter | Description |
-|-----------|-------------|
-| `progressive=true` | Serve the progressive JPEG variant for faster perceived load on slow networks. Falls back to the baseline image if the progressive variant is not available. |
+The Worker uses `Accept` header content negotiation for the base image endpoints. If the client sends `Accept: image/avif`, the AVIF variant is returned (falling back to JPEG if unavailable). Use the `format` query parameter above to override it explicitly; an unrecognised value is rejected with `400` rather than silently negotiated.
 
 ## Telemetry
 
@@ -234,12 +228,13 @@ just benchmark-generate --max-size 1536
 just benchmark-gate
 
 # Options (extra args forwarded to src/main.py)
-just generate --source unsplash   # Unsplash landscape (default)
-just generate --source met        # Metropolitan Museum
+just generate --source met        # Metropolitan Museum (default)
 just generate --source artic      # Art Institute of Chicago
+just generate --source unsplash   # Unsplash — needs UNSPLASH_ACCESS_KEY
 just generate --alpha 0.5         # subtle style (0.0-1.0)
 just generate --any-subject       # disable landscape filter
 just generate --max-size 1536     # higher processing resolution
+just generate --overwrite         # republish a date already in R2
 
 # List all available recipes
 just
@@ -281,6 +276,9 @@ just worker-check     # typecheck
 | `MEMORY_PROFILE` | `balanced` (default) or `low-memory`. `low-memory` caps `MAX_SIZE` at 1024 and disables variant generation by default to fit constrained CPU/RAM runners. |
 | `GENERATE_VARIANTS` | Generate AVIF and WebP variants alongside JPEG (default: `true`, or `false` in `low-memory`) |
 | `MAX_SIZE` | Max processing resolution in pixels (default: `1280`). Lower values are better for the current CPU-only/free-tier runner; `low-memory` caps this at `1024`. |
+| `METRICS_OUT` | Write run timing/resource metrics JSON to this path (also `--metrics-out`). Used by the benchmark workflow. |
+| `METRICS_LABEL` | Optional label recorded in the metrics JSON to annotate benchmark runs (also `--metrics-label`). |
+| `NTFY_TOPIC` | [ntfy.sh](https://ntfy.sh) topic for success/failure notifications. Set as a repository secret; notification steps are skipped when unset. |
 
 ### Secrets and deployment hygiene
 
@@ -301,9 +299,20 @@ To turn it on, set three repository secrets:
 
 | Secret | What it is |
 |--------|-----------|
-| `GPG_PRIVATE_KEY` | ASCII-armoured private key. Gates the import step — signing stays off until this is set. |
-| `GPG_KEY_ID` | Key ID or fingerprint, passed to `gpg --local-user`. Optional if the imported key is the default. |
-| `GPG_PASSPHRASE` | Passphrase, if the key has one. |
+| `GPG_PRIVATE_KEY` | ASCII-armoured private key. Gates the workflow's import step, and on its own is enough to enable signing. |
+| `GPG_KEY_ID` | Key ID or fingerprint, passed to `gpg --local-user`. Optional when the imported key is the only secret key present. |
+| `GPG_PASSPHRASE` | Passphrase, if the key has one. Omit for a passphrase-less key. |
+
+Setting any one of the three turns signing on. The signature covers the canonical JSON bytes that are uploaded, byte for byte.
+
+Verify a published day:
+
+```bash
+BASE=https://bauhaus.cascadiacollections.workers.dev
+curl -sf "$BASE/api/2026-01-02.json"     -o metadata.json
+curl -sf "$BASE/api/2026-01-02.json.sig" -o metadata.json.sig
+gpg --verify metadata.json.sig metadata.json
+```
 
 Generating and exporting a signing key:
 
@@ -321,17 +330,7 @@ gpg --armor --export-secret-keys <KEY_ID>
 gpg --armor --export <KEY_ID>
 ```
 
-Verifying a published day:
-
-```bash
-curl -sO https://bauhaus.cascadiacollections.workers.dev/api/2026-08-01.json
-curl -sO https://bauhaus.cascadiacollections.workers.dev/api/2026-08-01.json.sig
-gpg --verify 2026-08-01.json.sig 2026-08-01.json
-```
-
-Note that the signature covers the metadata JSON only, not the image bytes, and
-that `.json.sig` is not currently exposed as a Worker route — it exists in R2 at
-`metadata/<date>.json.sig` but the API has no handler for it yet.
+The signature covers the metadata JSON only, not the image bytes.
 
 ## Style references
 

--- a/models/download_models.py
+++ b/models/download_models.py
@@ -3,13 +3,18 @@
 # requires-python = ">=3.13"
 # dependencies = []
 # ///
-"""Download VGG-19 encoder and AdaIN decoder weights (cross-platform).
+"""Download and verify VGG-19 encoder and AdaIN decoder weights (cross-platform).
 
 Standalone — no project dependencies:
 
     uv run --script models/download_models.py
+
+Idempotent: files already on disk are checksummed and left alone when they
+match, re-downloaded when they do not. Safe to run before every generation.
 """
 
+import hashlib
+import sys
 from pathlib import Path
 from urllib.error import URLError
 from urllib.request import urlretrieve
@@ -17,24 +22,67 @@ from urllib.request import urlretrieve
 BASE_URL = "https://github.com/naoto0804/pytorch-AdaIN/releases/download/v0.0.0"
 WEIGHTS_DIR = Path(__file__).resolve().parent / "weights"
 
-_FILES = ("vgg_normalised.pth", "decoder.pth")
+# SHA-256 of each release asset, recorded 2026-08-01 from the upstream release.
+#
+# These pins are load-bearing twice over. urlretrieve() reports success for a
+# truncated body as long as the transfer ends cleanly, so without a checksum a
+# partial download is indistinguishable from a good one — and both generate
+# workflows cache models/weights, which would then serve that corrupt file to
+# every later run until a human manually evicted the cache. The release tag
+# (v0.0.0) is also mutable upstream, so pinning the bytes is the only thing
+# that makes "the model we tested" and "the model we run" the same artifact.
+_FILES: dict[str, str] = {
+    "vgg_normalised.pth": "804ca2835ecf7539f0cd2a7ac3c18ce81e6f8468969ae7117ac0c148d286bb4a",
+    "decoder.pth": "379ca41d59f3a37eed3599bbbc2560c19da5c458870a5ffd3a9dd41aa88f9472",
+}
+
+_CHUNK = 1024 * 1024
+
+
+def sha256_file(path: Path) -> str:
+    """Return the hex SHA-256 of a file, read in chunks."""
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        while chunk := fh.read(_CHUNK):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def download_models(weights_dir: Path = WEIGHTS_DIR) -> None:
-    """Download model files that are not already present."""
+    """Ensure every weight file is present and matches its recorded checksum."""
     weights_dir.mkdir(parents=True, exist_ok=True)
-    for name in _FILES:
+    for name, expected in _FILES.items():
         dest = weights_dir / name
+
         if dest.exists():
-            continue
+            actual = sha256_file(dest)
+            if actual == expected:
+                continue
+            print(
+                f"⚠ {name} checksum mismatch (have {actual[:12]}…, "
+                f"want {expected[:12]}…) — re-downloading",
+                file=sys.stderr,
+            )
+            dest.unlink()
+
         url = f"{BASE_URL}/{name}"
         print(f"Downloading {name}...")
         try:
-            urlretrieve(url, dest)  # noqa: S310 — trusted fixed URL
-        except URLError as exc:
+            urlretrieve(url, dest)  # noqa: S310 — trusted fixed URL, verified below
+        except (URLError, OSError) as exc:
             dest.unlink(missing_ok=True)  # remove partial download
             raise RuntimeError(f"Failed to download {name}: {exc}") from exc
-    print(f"Models ready in {weights_dir}")
+
+        actual = sha256_file(dest)
+        if actual != expected:
+            dest.unlink(missing_ok=True)
+            raise RuntimeError(
+                f"Checksum mismatch for {name}: expected {expected}, got {actual}. "
+                "The upstream asset changed or the download was corrupted; "
+                "the file has been removed."
+            )
+
+    print(f"Models ready and verified in {weights_dir}")
 
 
 if __name__ == "__main__":

--- a/src/fetch.py
+++ b/src/fetch.py
@@ -4,6 +4,7 @@ import os
 import random
 import re
 import sys
+import time
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from io import BytesIO
@@ -51,6 +52,28 @@ SKIP_SUBJECT_PATTERN = re.compile(
 )
 
 MAX_ATTEMPTS = 10
+
+# Backoff between *network* retries. Without it a source that is down absorbs
+# all ten attempts in about two seconds and the run dies having given the
+# upstream no time to recover — the opposite of what a retry loop is for.
+# Content rejections (NSFW title, quality gate) do not sleep: those consume an
+# attempt but nothing upstream needs to recover.
+RETRY_BACKOFF_BASE_SEC = 1.5
+RETRY_BACKOFF_MAX_SEC = 20.0
+
+
+def _retry_delay(attempt: int) -> float:
+    """Exponential backoff with jitter for retry number ``attempt`` (0-based)."""
+    capped = min(RETRY_BACKOFF_BASE_SEC * (2 ** attempt), RETRY_BACKOFF_MAX_SEC)
+    # Jitter spreads retries so a shared outage does not resynchronise them.
+    return capped * (0.5 + random.random() / 2)
+
+
+def _sleep_before_retry(attempt: int) -> None:
+    """Sleep between network retries, skipping the wait after the last one."""
+    if attempt >= MAX_ATTEMPTS - 1:
+        return
+    time.sleep(_retry_delay(attempt))
 
 
 @dataclass(slots=True)
@@ -196,6 +219,7 @@ def fetch_met(landscapes_only: bool = True, quality_gate: bool = True) -> Artwor
             )
         except requests.RequestException as e:
             print(f"Met attempt {attempt + 1} failed: {e}", file=sys.stderr)
+            _sleep_before_retry(attempt)
 
     raise RuntimeError(f"Failed to fetch from Met Museum after {MAX_ATTEMPTS} attempts")
 
@@ -258,13 +282,20 @@ def fetch_artic(landscapes_only: bool = True, quality_gate: bool = True) -> Artw
             )
         except requests.RequestException as e:
             print(f"AIC attempt {attempt + 1} failed: {e}", file=sys.stderr)
+            _sleep_before_retry(attempt)
 
     raise RuntimeError(f"Failed to fetch from AIC after {MAX_ATTEMPTS} attempts")
 
 
 def fetch_unsplash(landscapes_only: bool = True, quality_gate: bool = True) -> Artwork:
     """Fetch a random landscape photo from Unsplash."""
-    access_key = os.environ["UNSPLASH_ACCESS_KEY"]
+    try:
+        access_key = os.environ["UNSPLASH_ACCESS_KEY"]
+    except KeyError:
+        raise RuntimeError(
+            "UNSPLASH_ACCESS_KEY is not set. Unsplash needs an API key; the "
+            "CC0 museum sources do not — try --source met or --source artic."
+        ) from None
     for attempt in range(MAX_ATTEMPTS):
         try:
             params: dict = {}
@@ -312,6 +343,7 @@ def fetch_unsplash(landscapes_only: bool = True, quality_gate: bool = True) -> A
             )
         except requests.RequestException as e:
             print(f"Unsplash attempt {attempt + 1} failed: {e}", file=sys.stderr)
+            _sleep_before_retry(attempt)
 
     raise RuntimeError(f"Failed to fetch from Unsplash after {MAX_ATTEMPTS} attempts")
 

--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,7 @@ import random
 import socket
 import sys
 import time
-from datetime import UTC, date, datetime
+from datetime import UTC, datetime
 from io import BytesIO
 from math import gcd
 from pathlib import Path
@@ -22,7 +22,13 @@ from postprocess import postprocess
 from quality import aesthetic_score, score_image
 from sign_metadata import sign_metadata
 from stylize import StyleTransfer, gradient_alpha_mask, luminance_alpha_mask
-from upload import prepare_metadata_for_upload, serialize_metadata, upload
+from upload import (
+    AlreadyPublishedError,
+    prepare_metadata_for_upload,
+    serialize_metadata,
+    upload,
+    utc_today,
+)
 from variants import generate_variants
 
 STYLES_DIR = Path(__file__).resolve().parent.parent / "styles"
@@ -258,7 +264,7 @@ def pick_style(mode: str) -> tuple[Image.Image, dict]:
     if not styles:
         raise RuntimeError("No styles found in styles.json and STYLE_MODE=curated")
 
-    idx = date.today().timetuple().tm_yday % len(styles)
+    idx = utc_today().timetuple().tm_yday % len(styles)
     style_info = styles[idx]
 
     style_path = STYLES_DIR / style_info["filename"]
@@ -281,11 +287,15 @@ def resolve_runtime_profile(max_size: int, memory_profile: str, generate_variant
 
 
 def ensure_models():
-    """Download model weights if not present (cross-platform)."""
-    weights_dir = Path(__file__).resolve().parent.parent / "models" / "weights"
-    if (weights_dir / "vgg_normalised.pth").exists() and (weights_dir / "decoder.pth").exists():
-        return
+    """Download and verify model weights (cross-platform).
 
+    Always delegates to download_models.py rather than short-circuiting on file
+    existence: the script checksums what is already on disk and re-downloads on
+    mismatch. An existence check alone cannot tell a complete file from a
+    truncated one, and both generate workflows restore models/weights from an
+    Actions cache — so a single corrupt download would otherwise be cached and
+    replayed into every subsequent run with no way to self-heal.
+    """
     import subprocess
     script = Path(__file__).resolve().parent.parent / "models" / "download_models.py"
     subprocess.run([sys.executable, str(script)], check=True)
@@ -305,8 +315,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Generate daily stylized artwork")
     parser.add_argument("--dry-run", action="store_true",
                         help="Fetch and stylize locally, skip R2 upload")
-    parser.add_argument("--source", default="unsplash", choices=["unsplash", "met", "artic"],
-                        help="Art source (default: unsplash)")
+    # Default to a CC0 museum source: it needs no API key, so `just generate`
+    # works on a fresh clone, and it matches what both generate workflows run.
+    parser.add_argument("--source", default="met", choices=["unsplash", "met", "artic"],
+                        help="Art source (default: met)")
+    parser.add_argument("--overwrite", action="store_true",
+                        help="Republish a date that already exists in R2 "
+                             "(date keys are served immutable — see docs)")
     parser.add_argument("--alpha", type=float, default=0.8,
                         help="Style strength 0.0-1.0 (default: 0.8)")
     parser.add_argument("--alpha-mode", default="uniform",
@@ -524,7 +539,7 @@ def main():
     # Add structured license details and variant descriptors
     metadata["license_details"] = build_license_details(metadata)
     # Capture today once to avoid day-boundary skew between manifest and upload
-    today = date.today()
+    today = utc_today()
     today_str = today.isoformat()
     metadata["variants"] = build_variants(
         stylized, stylized_bytes,
@@ -567,7 +582,12 @@ def main():
     metadata_sig: bytes | None = None
     gpg_key_id = os.environ.get("GPG_KEY_ID")
     gpg_passphrase = os.environ.get("GPG_PASSPHRASE")
-    if gpg_key_id or gpg_passphrase:
+    # GPG_PRIVATE_KEY is what the workflows gate the key *import* on, and the
+    # README's `gpg --quick-generate-key ... never` recipe produces a
+    # passphrase-less default key — no key id, no passphrase. Gating signing on
+    # key id or passphrase alone meant following the README exactly imported a
+    # key and then silently never signed with it.
+    if gpg_key_id or gpg_passphrase or os.environ.get("GPG_PRIVATE_KEY"):
         print("Signing metadata with PGP key...")
         metadata_sig = sign_metadata(
             metadata_json.decode("utf-8"),
@@ -624,14 +644,19 @@ def main():
     # 7. Upload to R2
     t = time.perf_counter()
     print("Uploading to R2...")
-    keys = upload(
-        original_bytes, stylized_bytes, prepared_metadata,
-        manifest=manifest,
-        today=today,
-        variants=variants,
-        stripped_bytes=stripped_bytes,
-        metadata_sig=metadata_sig,
-    )
+    try:
+        keys = upload(
+            original_bytes, stylized_bytes, prepared_metadata,
+            manifest=manifest,
+            today=today,
+            variants=variants,
+            stripped_bytes=stripped_bytes,
+            metadata_sig=metadata_sig,
+            overwrite=args.overwrite,
+        )
+    except AlreadyPublishedError as exc:
+        print(f"\n✗ {exc}", file=sys.stderr)
+        sys.exit(1)
     record_timing("upload", t)
     print("Uploaded:")
     for name, key in keys.items():

--- a/src/upload.py
+++ b/src/upload.py
@@ -6,6 +6,7 @@ from datetime import UTC, date, datetime
 from functools import lru_cache
 
 import boto3
+from botocore.exceptions import ClientError
 
 # Content types for all supported image variant suffixes.
 _VARIANT_CONTENT_TYPES: dict[str, str] = {
@@ -14,6 +15,32 @@ _VARIANT_CONTENT_TYPES: dict[str, str] = {
     "progressive.jpg": "image/jpeg",
     "stripped.jpg": "image/jpeg",
 }
+
+# Date-keyed objects are published once and never rewritten, so they are safe to
+# cache indefinitely. This string must stay byte-identical to IMMUTABLE_CACHE in
+# worker/src/index.ts: the Worker prefers the header stored on the R2 object and
+# only falls back to its own constant, so a mismatch here is what actually gets
+# served, and the Worker's value becomes unreachable for pipeline-written keys.
+IMMUTABLE_CACHE = "public, max-age=31536000, s-maxage=31536000, immutable"
+
+# latest.json is a pointer that changes daily — short cache, revalidate often.
+LATEST_CACHE = "public, max-age=300"
+
+
+class AlreadyPublishedError(RuntimeError):
+    """Raised when a date already has published objects and overwrite is off."""
+
+
+def utc_today() -> date:
+    """Today's date in UTC.
+
+    The publish date must never depend on the runner's local timezone. Hosted
+    runners are UTC, but generate-self-hosted.yml runs this same code on a
+    Pacific-time Mac Mini: a PT-evening dispatch (including 8 PM PT, the time
+    the README advertises) would compute *yesterday's* date there, overwrite
+    the previous day's keys, and rewind latest.json.
+    """
+    return datetime.now(UTC).date()
 
 
 @lru_cache(maxsize=1)
@@ -33,7 +60,7 @@ def prepare_metadata_for_upload(
     generated_at: datetime | None = None,
 ) -> dict:
     """Return metadata augmented with stable upload-time fields."""
-    today = today or date.today()
+    today = today or utc_today()
     prepared = dict(metadata)
     prepared.setdefault("date", today.isoformat())
     prepared.setdefault("generated_at", (generated_at or datetime.now(UTC)).isoformat())
@@ -43,6 +70,39 @@ def prepare_metadata_for_upload(
 def serialize_metadata(metadata: dict) -> bytes:
     """Serialize metadata with canonical ordering for signing + upload."""
     return json.dumps(metadata, indent=2, sort_keys=True).encode()
+
+
+def _assert_unpublished(client, bucket: str, date_path: str, today: date) -> None:
+    """Refuse to overwrite a date that has already been published.
+
+    Every date-keyed object is served with `immutable` and a one-year TTL, which
+    is a promise that the bytes behind that URL never change. Re-running a date
+    breaks that promise in a way no cache ever recovers from: uploads land
+    key-by-key rather than atomically, so a client that fetched during the
+    rewrite can hold the image from one artwork alongside the metadata of
+    another — permanently, because `immutable` tells it never to revalidate.
+
+    Publishing is therefore write-once by default. Pass overwrite=True
+    (`--overwrite`, or the workflow_dispatch input) to republish a date
+    deliberately, accepting that already-cached copies stay stale.
+    """
+    key = f"metadata/{date_path}.json"
+    try:
+        client.head_object(Bucket=bucket, Key=key)
+    except ClientError as exc:
+        # 404/NoSuchKey is the expected path: nothing published for this date.
+        status = exc.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+        code = exc.response.get("Error", {}).get("Code")
+        if status == 404 or code in {"404", "NoSuchKey", "NotFound"}:
+            return
+        raise
+
+    raise AlreadyPublishedError(
+        f"{today.isoformat()} is already published (found {key}). "
+        "Date keys are served immutable, so rewriting them leaves stale and "
+        "possibly mismatched copies in caches forever. Re-run with --overwrite "
+        "if that is what you want."
+    )
 
 
 def upload(
@@ -55,13 +115,22 @@ def upload(
     variants: dict[str, bytes] | None = None,
     stripped_bytes: bytes | None = None,
     metadata_sig: bytes | None = None,
+    overwrite: bool = False,
 ) -> dict[str, str]:
-    """Upload original, stylized, variants, manifest, and metadata to R2. Returns dict of uploaded keys."""
+    """Upload original, stylized, variants, manifest, and metadata to R2. Returns dict of uploaded keys.
+
+    Raises AlreadyPublishedError when ``today`` has already been published and
+    ``overwrite`` is False — see _assert_unpublished().
+    """
     bucket = bucket or os.environ.get("R2_BUCKET", "bauhaus")
-    today = today or date.today()
+    today = today or utc_today()
     date_path = today.strftime("%Y/%m/%d")
 
     client = _get_client()
+
+    if not overwrite:
+        _assert_unpublished(client, bucket, date_path, today)
+
     keys = {}
 
     # Original image
@@ -71,7 +140,7 @@ def upload(
         Key=key,
         Body=original_bytes,
         ContentType="image/jpeg",
-        CacheControl="public, max-age=31536000, immutable",
+        CacheControl=IMMUTABLE_CACHE,
     )
     keys["original"] = key
 
@@ -82,7 +151,7 @@ def upload(
         Key=key,
         Body=stylized_bytes,
         ContentType="image/jpeg",
-        CacheControl="public, max-age=31536000, immutable",
+        CacheControl=IMMUTABLE_CACHE,
     )
     keys["stylized"] = key
 
@@ -104,7 +173,7 @@ def upload(
                 Key=key,
                 Body=data,
                 ContentType=_VARIANT_CONTENT_TYPES.get(suffix, f"image/{suffix.split('.')[-1]}"),
-                CacheControl="public, max-age=31536000, immutable",
+                CacheControl=IMMUTABLE_CACHE,
             )
             keys[f"stylized_{suffix.replace('.', '_')}"] = key
 
@@ -117,7 +186,7 @@ def upload(
         Key=key,
         Body=metadata_bytes,
         ContentType="application/json",
-        CacheControl="public, max-age=31536000, immutable",
+        CacheControl=IMMUTABLE_CACHE,
     )
     keys["metadata"] = key
 
@@ -129,7 +198,7 @@ def upload(
             Key=key,
             Body=metadata_sig,
             ContentType="application/pgp-signature",
-            CacheControl="public, max-age=31536000, immutable",
+            CacheControl=IMMUTABLE_CACHE,
         )
         keys["metadata_sig"] = key
 
@@ -141,7 +210,7 @@ def upload(
             Key=key,
             Body=json.dumps(manifest, indent=2).encode(),
             ContentType="application/json",
-            CacheControl="public, max-age=31536000, immutable",
+            CacheControl=IMMUTABLE_CACHE,
         )
         keys["manifest"] = key
 
@@ -153,7 +222,7 @@ def upload(
             Key=key,
             Body=stripped_bytes,
             ContentType="image/jpeg",
-            CacheControl="public, max-age=31536000, immutable",
+            CacheControl=IMMUTABLE_CACHE,
         )
         keys["stripped"] = key
 
@@ -163,7 +232,7 @@ def upload(
         Key="latest.json",
         Body=json.dumps({"date": today.isoformat()}).encode(),
         ContentType="application/json",
-        CacheControl="public, max-age=300",
+        CacheControl=LATEST_CACHE,
     )
     keys["latest"] = "latest.json"
 

--- a/src/variants.py
+++ b/src/variants.py
@@ -14,7 +14,8 @@ def generate_variants(
 
     Returns a dict mapping variant suffix (e.g. ``"avif"``, ``"webp"``,
     ``"progressive.jpg"``, ``"stripped.jpg"``) to the encoded bytes.
-    AVIF is silently skipped when the codec is unavailable.
+    AVIF is skipped with a warning on stderr when the codec is unavailable;
+    the other variants are always produced.
 
     Args:
         image: PIL Image to encode.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,5 +3,9 @@
 import sys
 from pathlib import Path
 
-# Add src/ to sys.path so tests can import source modules directly.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+_ROOT = Path(__file__).resolve().parent
+
+# Add src/ to sys.path so tests can import source modules directly, and this
+# directory so tests can import helpers.py.
+sys.path.insert(0, str(_ROOT.parent / "src"))
+sys.path.insert(0, str(_ROOT))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,26 @@
+"""Shared test helpers.
+
+Importable because conftest.py puts this directory on sys.path.
+"""
+
+from unittest.mock import MagicMock
+
+from botocore.exceptions import ClientError
+
+
+def make_r2_client(published: bool = False) -> MagicMock:
+    """A mock S3 client whose head_object reports the date as un/published.
+
+    upload() refuses to overwrite an already-published date, so head_object has
+    to answer that question. A bare MagicMock would return a truthy object and
+    make every date look published; this makes "nothing there yet" the default,
+    which is what a normal daily run sees.
+    """
+    client = MagicMock()
+    if not published:
+        client.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"},
+             "ResponseMetadata": {"HTTPStatusCode": 404}},
+            "HeadObject",
+        )
+    return client

--- a/tests/test_download_models.py
+++ b/tests/test_download_models.py
@@ -1,0 +1,120 @@
+"""Tests for models/download_models.py checksum verification.
+
+The weights are cached in CI under a key derived from this script, and
+urlretrieve() reports success for a truncated body, so the checksum is the only
+thing standing between a corrupt download and every later run replaying it out
+of the Actions cache.
+"""
+
+import hashlib
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "models" / "download_models.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("download_models", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["download_models"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+dm = _load_module()
+
+
+class TestPinnedChecksums:
+    def test_every_file_has_a_sha256(self):
+        assert set(dm._FILES) == {"vgg_normalised.pth", "decoder.pth"}
+        for name, digest in dm._FILES.items():
+            assert len(digest) == 64, f"{name} checksum is not a SHA-256 hex digest"
+            int(digest, 16)  # raises unless hex
+
+    def test_stylize_loads_exactly_these_files(self):
+        """A weight file renamed in one place and not the other fails silently."""
+        stylize_src = (
+            Path(__file__).resolve().parent.parent / "src" / "stylize.py"
+        ).read_text(encoding="utf-8")
+        for name in dm._FILES:
+            assert name in stylize_src, f"{name} is downloaded but never loaded"
+
+
+class TestSha256File:
+    def test_matches_hashlib(self, tmp_path):
+        target = tmp_path / "blob.bin"
+        payload = b"bauhaus" * 5000
+        target.write_bytes(payload)
+        assert dm.sha256_file(target) == hashlib.sha256(payload).hexdigest()
+
+    def test_reads_files_larger_than_one_chunk(self, tmp_path):
+        target = tmp_path / "big.bin"
+        payload = b"x" * (dm._CHUNK * 2 + 17)
+        target.write_bytes(payload)
+        assert dm.sha256_file(target) == hashlib.sha256(payload).hexdigest()
+
+
+class TestDownloadModels:
+    def _pin(self, monkeypatch, payload: bytes, name: str = "decoder.pth"):
+        monkeypatch.setattr(dm, "_FILES", {name: hashlib.sha256(payload).hexdigest()})
+
+    def test_valid_existing_file_is_not_redownloaded(self, tmp_path, monkeypatch):
+        payload = b"good-weights"
+        self._pin(monkeypatch, payload)
+        (tmp_path / "decoder.pth").write_bytes(payload)
+
+        called = []
+        monkeypatch.setattr(dm, "urlretrieve", lambda *a, **k: called.append(a))
+        dm.download_models(tmp_path)
+        assert called == []
+
+    def test_corrupt_existing_file_is_replaced(self, tmp_path, monkeypatch):
+        """The cached-corruption case: a truncated file already on disk."""
+        payload = b"good-weights"
+        self._pin(monkeypatch, payload)
+        dest = tmp_path / "decoder.pth"
+        dest.write_bytes(b"truncated")
+
+        def fake_retrieve(url, target):
+            Path(target).write_bytes(payload)
+
+        monkeypatch.setattr(dm, "urlretrieve", fake_retrieve)
+        dm.download_models(tmp_path)
+        assert dest.read_bytes() == payload
+
+    def test_download_with_bad_checksum_raises_and_removes_the_file(self, tmp_path, monkeypatch):
+        self._pin(monkeypatch, b"expected-content")
+
+        def fake_retrieve(url, target):
+            Path(target).write_bytes(b"something-else")
+
+        monkeypatch.setattr(dm, "urlretrieve", fake_retrieve)
+        with pytest.raises(RuntimeError, match="Checksum mismatch"):
+            dm.download_models(tmp_path)
+        assert not (tmp_path / "decoder.pth").exists()
+
+    def test_missing_file_is_downloaded(self, tmp_path, monkeypatch):
+        payload = b"fresh-weights"
+        self._pin(monkeypatch, payload)
+
+        def fake_retrieve(url, target):
+            Path(target).write_bytes(payload)
+
+        monkeypatch.setattr(dm, "urlretrieve", fake_retrieve)
+        dm.download_models(tmp_path)
+        assert (tmp_path / "decoder.pth").read_bytes() == payload
+
+    def test_network_failure_cleans_up_the_partial_file(self, tmp_path, monkeypatch):
+        self._pin(monkeypatch, b"never-arrives")
+
+        def fake_retrieve(url, target):
+            Path(target).write_bytes(b"half-a-fi")
+            raise OSError("connection reset")
+
+        monkeypatch.setattr(dm, "urlretrieve", fake_retrieve)
+        with pytest.raises(RuntimeError, match="Failed to download"):
+            dm.download_models(tmp_path)
+        assert not (tmp_path / "decoder.pth").exists()

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,6 +1,19 @@
 """Tests for fetch.py — title filtering and Artwork dataclass."""
 
-from fetch import Artwork, fetch_artwork, is_landscape, is_preferred_subject, is_safe_title
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+import fetch
+from fetch import (
+    _FETCHERS,
+    Artwork,
+    fetch_artwork,
+    is_landscape,
+    is_preferred_subject,
+    is_safe_title,
+)
 
 # --- is_safe_title ---
 
@@ -154,15 +167,18 @@ class TestArtworkToMetadata:
 # --- fetch_artwork source registration ---
 
 class TestFetchArtworkSources:
-    def test_all_sources_valid(self):
-        fetchers = {"unsplash", "met", "artic"}
-        # Verify all expected sources are registered by checking fetch_artwork doesn't raise ValueError
-        for source in fetchers:
-            try:
-                fetch_artwork(source, landscapes_only=True)
-            except (RuntimeError, Exception):
-                # Network errors are fine — we just want to confirm no ValueError
-                pass
+    def test_all_sources_registered(self):
+        """Every documented source resolves to a fetcher.
+
+        Asserts against the registry rather than calling fetch_artwork(): the
+        previous version called it for real — up to 10 live HTTP requests per
+        source, from CI — inside `except (RuntimeError, Exception)`, which
+        swallows the very ValueError it claimed to be checking for and so could
+        not fail for its stated reason.
+        """
+        assert set(_FETCHERS) == {"unsplash", "met", "artic"}
+        for fetcher in _FETCHERS.values():
+            assert callable(fetcher)
 
     def test_unknown_source_raises(self):
         import pytest
@@ -218,3 +234,59 @@ class TestCheckQualityOrientation:
         passed, reason = _check_quality(b"not an image", landscape_orientation=True)
         assert passed is False
         assert "decode" in reason
+
+
+class TestRetryBackoff:
+    """Network retries back off; content rejections do not.
+
+    Without a delay a source that is down absorbed all ten attempts in about
+    two seconds, so the retry loop gave the upstream no chance to recover.
+    """
+
+    def test_delay_grows_with_attempt(self):
+        with patch("fetch.random.random", return_value=1.0):
+            delays = [fetch._retry_delay(i) for i in range(4)]
+        assert delays == sorted(delays)
+        assert delays[0] < delays[-1]
+
+    def test_delay_is_capped(self):
+        with patch("fetch.random.random", return_value=1.0):
+            assert fetch._retry_delay(50) <= fetch.RETRY_BACKOFF_MAX_SEC
+
+    def test_delay_is_jittered(self):
+        """Jitter keeps a shared outage from resynchronising every retry."""
+        with patch("fetch.random.random", return_value=0.0):
+            low = fetch._retry_delay(3)
+        with patch("fetch.random.random", return_value=1.0):
+            high = fetch._retry_delay(3)
+        assert low < high
+
+    def test_no_sleep_after_the_final_attempt(self):
+        """The last failure raises immediately — nothing left to wait for."""
+        with patch("fetch.time.sleep") as sleep:
+            fetch._sleep_before_retry(fetch.MAX_ATTEMPTS - 1)
+        assert sleep.call_count == 0
+
+    def test_sleeps_between_earlier_attempts(self):
+        with patch("fetch.time.sleep") as sleep:
+            fetch._sleep_before_retry(0)
+        assert sleep.call_count == 1
+        assert sleep.call_args.args[0] > 0
+
+    def test_network_failure_backs_off_then_raises(self):
+        """Ten failed attempts, nine waits, one clean RuntimeError."""
+        with patch("fetch._get", side_effect=requests.RequestException("down")), \
+             patch("fetch.time.sleep") as sleep, \
+             pytest.raises(RuntimeError, match="after 10 attempts"):
+            fetch.fetch_met()
+        assert sleep.call_count == fetch.MAX_ATTEMPTS - 1
+
+    def test_content_rejection_does_not_sleep(self):
+        """An empty search result is not an outage — retry straight away."""
+        empty = MagicMock()
+        empty.json.return_value = {"objectIDs": []}
+        with patch("fetch._get", return_value=empty), \
+             patch("fetch.time.sleep") as sleep, \
+             pytest.raises(RuntimeError):
+            fetch.fetch_met()
+        assert sleep.call_count == 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,5 @@
 """Tests for main.py — styles manifest, style rotation, CLI args, and metadata helpers."""
 
-import argparse
 import os
 from io import BytesIO
 from unittest.mock import patch
@@ -76,42 +75,36 @@ class TestVariantsCLIArg:
 
 
 class TestMaxSizeCLIArg:
-    """Tests for --max-size CLI flag and MAX_SIZE env var."""
+    """Tests for --max-size CLI flag and MAX_SIZE env var.
+
+    These build the parser under test via build_parser(). They previously
+    constructed a throwaway ArgumentParser with the default duplicated inline,
+    so they asserted 1920 while the real default was 1280 and would have passed
+    with --max-size deleted from the CLI entirely.
+    """
 
     def test_default_max_size(self):
-        """Default --max-size should be 1920 when no env var is set."""
+        """Default --max-size should be 1280 when no env var is set."""
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("MAX_SIZE", None)
-            parser = argparse.ArgumentParser()
-            parser.add_argument("--max-size", type=int,
-                                default=int(os.environ.get("MAX_SIZE", "1920")))
-            args = parser.parse_args([])
-            assert args.max_size == 1920
+            args = build_parser().parse_args([])
+            assert args.max_size == 1280
 
     def test_cli_flag_overrides_default(self):
         """--max-size flag should override the default."""
-        parser = argparse.ArgumentParser()
-        parser.add_argument("--max-size", type=int,
-                            default=int(os.environ.get("MAX_SIZE", "1920")))
-        args = parser.parse_args(["--max-size", "1536"])
+        args = build_parser().parse_args(["--max-size", "1536"])
         assert args.max_size == 1536
 
     def test_env_var_sets_default(self):
         """MAX_SIZE env var should set the default when no flag is passed."""
         with patch.dict(os.environ, {"MAX_SIZE": "1920"}):
-            parser = argparse.ArgumentParser()
-            parser.add_argument("--max-size", type=int,
-                                default=int(os.environ.get("MAX_SIZE", "1920")))
-            args = parser.parse_args([])
+            args = build_parser().parse_args([])
             assert args.max_size == 1920
 
     def test_cli_flag_overrides_env_var(self):
         """--max-size flag should override MAX_SIZE env var."""
         with patch.dict(os.environ, {"MAX_SIZE": "1920"}):
-            parser = argparse.ArgumentParser()
-            parser.add_argument("--max-size", type=int,
-                                default=int(os.environ.get("MAX_SIZE", "1920")))
-            args = parser.parse_args(["--max-size", "768"])
+            args = build_parser().parse_args(["--max-size", "768"])
             assert args.max_size == 768
 
 

--- a/tests/test_main_pipeline.py
+++ b/tests/test_main_pipeline.py
@@ -1,0 +1,206 @@
+"""End-to-end orchestration tests for main().
+
+main() is where the pipeline's ordering, gating and plumbing live, and it was
+the largest wholly untested surface in the project: every module it calls had
+unit tests, but nothing exercised the sequence that wires them together. These
+tests patch the expensive leaves (network, model, R2) and assert on what main()
+does with them.
+"""
+
+import os
+import sys
+from datetime import date
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+
+import main as main_mod
+from fetch import Artwork
+from upload import AlreadyPublishedError
+
+# Environment variables main() reads that would otherwise leak in from the
+# developer's shell and change what these tests exercise.
+_CONTROLLED_ENV = frozenset({
+    "GPG_KEY_ID", "GPG_PASSPHRASE", "GPG_PRIVATE_KEY",
+    "STYLE_MODE", "LANDSCAPES_ONLY", "MEMORY_PROFILE",
+    "GENERATE_VARIANTS", "MAX_SIZE", "METRICS_OUT", "METRICS_LABEL",
+})
+
+
+def _jpeg(width: int = 400, height: int = 300) -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (width, height), (90, 120, 160)).save(buf, format="JPEG", quality=70)
+    return buf.getvalue()
+
+
+def _artwork() -> Artwork:
+    return Artwork(
+        title="A Wide Valley",
+        artist="Test Painter",
+        date="1889",
+        source="met",
+        source_url="https://www.metmuseum.org/art/collection/search/1",
+        image_bytes=_jpeg(),
+    )
+
+
+class _Harness:
+    """Patches every expensive dependency of main() and records the calls."""
+
+    def __init__(self, argv: list[str], env: dict[str, str] | None = None):
+        self.argv = ["main.py", *argv]
+        self.env = env or {}
+        self.upload = MagicMock(return_value={"stylized": "stylized/2026/01/02.jpg"})
+        self.sign = MagicMock(return_value=b"-----BEGIN PGP SIGNATURE-----")
+        self.fetch = MagicMock(return_value=_artwork())
+        self.ensure_models = MagicMock()
+
+    def __enter__(self):
+        style_img = Image.new("RGB", (256, 256), (200, 60, 40))
+        stylized = Image.new("RGB", (400, 300), (30, 90, 150))
+
+        transfer = MagicMock()
+        transfer.transfer.return_value = stylized
+
+        # Start from the real environment minus every variable these tests care
+        # about, so a developer's exported GPG_* or STYLE_MODE cannot change the
+        # result, then layer this case's values on top.
+        env = {k: v for k, v in os.environ.items() if k not in _CONTROLLED_ENV}
+        env.update(self.env)
+
+        self._patches = [
+            patch.object(sys, "argv", self.argv),
+            patch.dict(os.environ, env, clear=True),
+            patch.object(main_mod, "fetch_artwork", self.fetch),
+            patch.object(main_mod, "pick_style", return_value=(style_img, {"style_title": "Rain"})),
+            patch.object(main_mod, "ensure_models", self.ensure_models),
+            patch.object(main_mod, "StyleTransfer", MagicMock(return_value=transfer)),
+            patch.object(main_mod, "upload", self.upload),
+            patch.object(main_mod, "sign_metadata", self.sign),
+            patch.object(main_mod, "utc_today", return_value=date(2026, 1, 2)),
+        ]
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, *exc):
+        for p in reversed(self._patches):
+            p.stop()
+        return False
+
+
+class TestMainOrchestration:
+    def test_uploads_with_the_fetched_and_stylized_artwork(self):
+        with _Harness(["--source", "met"]) as h:
+            main_mod.main()
+
+        assert h.upload.call_count == 1
+        kwargs = h.upload.call_args.kwargs
+        args = h.upload.call_args.args
+        metadata = args[2]
+        assert metadata["title"] == "A Wide Valley"
+        assert metadata["style_title"] == "Rain"
+        assert metadata["license"] == "CC0-1.0"
+        assert kwargs["today"] == date(2026, 1, 2)
+
+    def test_models_are_ensured_before_style_transfer(self):
+        """A missing or corrupt weight file must surface before the GPU work."""
+        with _Harness([]) as h:
+            main_mod.main()
+        assert h.ensure_models.call_count == 1
+
+    def test_source_flag_reaches_the_fetcher(self):
+        with _Harness(["--source", "artic"]) as h:
+            main_mod.main()
+        assert h.fetch.call_args.args[0] == "artic"
+
+    def test_landscapes_only_defaults_on(self):
+        with _Harness([]) as h:
+            main_mod.main()
+        assert h.fetch.call_args.kwargs["landscapes_only"] is True
+
+    def test_any_subject_disables_the_landscape_filter(self):
+        with _Harness(["--any-subject"]) as h:
+            main_mod.main()
+        assert h.fetch.call_args.kwargs["landscapes_only"] is False
+
+    def test_dry_run_never_uploads(self, tmp_path):
+        with _Harness(["--dry-run"]) as h, patch.object(main_mod, "OUTPUT_DIR", tmp_path):
+            main_mod.main()
+        assert h.upload.call_count == 0
+        assert (tmp_path / "stylized.jpg").exists()
+        assert (tmp_path / "metadata.json").exists()
+
+    def test_overwrite_flag_is_plumbed_through(self):
+        with _Harness(["--overwrite"]) as h:
+            main_mod.main()
+        assert h.upload.call_args.kwargs["overwrite"] is True
+
+    def test_overwrite_defaults_off(self):
+        with _Harness([]) as h:
+            main_mod.main()
+        assert h.upload.call_args.kwargs["overwrite"] is False
+
+    def test_already_published_exits_nonzero(self):
+        with _Harness([]) as h:
+            h.upload.side_effect = AlreadyPublishedError("2026-01-02 is already published")
+            with pytest.raises(SystemExit) as exc:
+                main_mod.main()
+        assert exc.value.code == 1
+
+    def test_signed_bytes_are_the_uploaded_bytes(self):
+        """The signature must cover exactly the JSON that lands in R2."""
+        with _Harness([], env={"GPG_KEY_ID": "ABC123"}) as h:
+            main_mod.main()
+
+        signed_text = h.sign.call_args.args[0]
+        uploaded_metadata = h.upload.call_args.args[2]
+        from upload import prepare_metadata_for_upload, serialize_metadata
+        expected = serialize_metadata(
+            prepare_metadata_for_upload(uploaded_metadata, today=date(2026, 1, 2)),
+        ).decode()
+        assert signed_text == expected
+        assert h.upload.call_args.kwargs["metadata_sig"] == b"-----BEGIN PGP SIGNATURE-----"
+
+
+class TestGpgGating:
+    """Signing must engage for the configuration the README tells people to use."""
+
+    def test_signs_with_private_key_alone(self):
+        """The README's recipe yields a passphrase-less default key: no id, no passphrase.
+
+        Gating on key id or passphrase meant following the README imported a
+        key and then never signed with it.
+        """
+        with _Harness([], env={"GPG_PRIVATE_KEY": "-----BEGIN PGP PRIVATE KEY BLOCK-----"}) as h:
+            main_mod.main()
+        assert h.sign.call_count == 1
+        assert h.sign.call_args.kwargs["key_id"] is None
+        assert h.sign.call_args.kwargs["passphrase"] is None
+
+    def test_signs_with_key_id(self):
+        with _Harness([], env={"GPG_KEY_ID": "DEADBEEF"}) as h:
+            main_mod.main()
+        assert h.sign.call_count == 1
+        assert h.sign.call_args.kwargs["key_id"] == "DEADBEEF"
+
+    def test_signs_with_passphrase_only(self):
+        with _Harness([], env={"GPG_PASSPHRASE": "hunter2"}) as h:
+            main_mod.main()
+        assert h.sign.call_count == 1
+
+    def test_no_gpg_config_means_no_signature(self):
+        with _Harness([]) as h:
+            main_mod.main()
+        assert h.sign.call_count == 0
+        assert h.upload.call_args.kwargs["metadata_sig"] is None
+
+    def test_failed_signing_does_not_abort_the_run(self):
+        """sign_metadata() returns None on failure; publishing must continue."""
+        with _Harness([], env={"GPG_KEY_ID": "DEADBEEF"}) as h:
+            h.sign.return_value = None
+            main_mod.main()
+        assert h.upload.call_count == 1
+        assert h.upload.call_args.kwargs["metadata_sig"] is None

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -113,8 +113,10 @@ class TestCheckAspectRatio:
         img = _solid_image((0, 0, 0), (100, 4000))
         assert check_aspect_ratio(img) is False
 
-    def test_zero_height(self):
-        # Edge case — 100×1 gives ratio 100 which exceeds MAX_ASPECT_RATIO
+    def test_extreme_ratio_rejected(self):
+        # 100x1 gives ratio 100, far above MAX_ASPECT_RATIO. Named for what
+        # it tests: PIL cannot construct a zero-height image, so the h == 0
+        # guard in check_aspect_ratio is unreachable from here.
         img = _solid_image((0, 0, 0), (100, 1))
         assert check_aspect_ratio(img) is False
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,10 +1,24 @@
 """Tests for upload.py — key generation, metadata enrichment, and S3 calls."""
 
 import json
+import re
 from datetime import UTC, date, datetime
-from unittest.mock import MagicMock, patch
+from pathlib import Path
+from unittest.mock import patch
 
-from upload import prepare_metadata_for_upload, serialize_metadata, upload
+import pytest
+from botocore.exceptions import ClientError
+from helpers import make_r2_client
+
+from upload import (
+    IMMUTABLE_CACHE,
+    LATEST_CACHE,
+    AlreadyPublishedError,
+    prepare_metadata_for_upload,
+    serialize_metadata,
+    upload,
+    utc_today,
+)
 
 
 class TestUpload:
@@ -16,7 +30,7 @@ class TestUpload:
         stripped_bytes: bytes | None = None,
     ):
         today = today or date(2025, 7, 14)
-        mock_client = MagicMock()
+        mock_client = make_r2_client()
 
         with patch("upload._get_client", return_value=mock_client):
             keys = upload(
@@ -131,7 +145,7 @@ class TestUploadVariants:
 
     def _run_upload(self, variants=None, manifest=None, today=None):
         today = today or date(2025, 7, 14)
-        mock_client = MagicMock()
+        mock_client = make_r2_client()
         with patch("upload._get_client", return_value=mock_client):
             keys = upload(
                 original_bytes=b"original-data",
@@ -193,7 +207,7 @@ class TestUploadMetadataSig:
     def _run_upload(self, metadata_sig=None, today=None):
         from datetime import date
         today = today or date(2025, 7, 14)
-        mock_client = MagicMock()
+        mock_client = make_r2_client()
         with patch("upload._get_client", return_value=mock_client):
             keys = upload(
                 original_bytes=b"original-data",
@@ -256,7 +270,7 @@ class TestUploadMetadataSig:
         )
         expected_bytes = serialize_metadata(prepared)
 
-        mock_client = MagicMock()
+        mock_client = make_r2_client()
         with patch("upload._get_client", return_value=mock_client):
             upload(
                 original_bytes=b"original-data",
@@ -281,7 +295,7 @@ class TestStrippedVariantNotDuplicated:
     default path used to PUT the same key twice."""
 
     def _upload(self, **kwargs):
-        mock_client = MagicMock()
+        mock_client = make_r2_client()
         with patch("upload._get_client", return_value=mock_client):
             keys = upload(
                 b"original", b"stylized", {"title": "t"},
@@ -321,3 +335,146 @@ class TestStrippedVariantNotDuplicated:
         )
         for suffix in ("avif", "webp", "progressive.jpg"):
             assert f"stylized/2026/01/02.{suffix}" in put_keys
+
+
+class TestWriteOnceGuard:
+    """upload() refuses to rewrite a date that has already been published.
+
+    Date keys are served with `immutable` and a one-year TTL. Rewriting them
+    leaves caches holding bytes they will never revalidate, and because uploads
+    land key-by-key a client can end up with one artwork's image beside another
+    artwork's metadata, permanently.
+    """
+
+    def _upload(self, client, **kwargs):
+        with patch("upload._get_client", return_value=client):
+            return upload(
+                original_bytes=b"original-data",
+                stylized_bytes=b"stylized-data",
+                metadata={"title": "Test Art"},
+                bucket="test-bucket",
+                today=date(2026, 1, 2),
+                **kwargs,
+            )
+
+    def test_unpublished_date_uploads(self):
+        client = make_r2_client(published=False)
+        keys = self._upload(client)
+        assert keys["metadata"] == "metadata/2026/01/02.json"
+
+    def test_published_date_raises(self):
+        client = make_r2_client(published=True)
+        with pytest.raises(AlreadyPublishedError, match="2026-01-02"):
+            self._upload(client)
+
+    def test_published_date_writes_nothing(self):
+        """The guard must run before the first PUT, not partway through."""
+        client = make_r2_client(published=True)
+        with pytest.raises(AlreadyPublishedError):
+            self._upload(client)
+        assert client.put_object.call_count == 0
+
+    def test_overwrite_allows_republish(self):
+        client = make_r2_client(published=True)
+        keys = self._upload(client, overwrite=True)
+        assert keys["metadata"] == "metadata/2026/01/02.json"
+
+    def test_overwrite_skips_the_existence_check(self):
+        client = make_r2_client(published=True)
+        self._upload(client, overwrite=True)
+        assert client.head_object.call_count == 0
+
+    def test_guard_checks_the_metadata_key_for_the_run_date(self):
+        client = make_r2_client(published=False)
+        self._upload(client)
+        assert client.head_object.call_args.kwargs["Key"] == "metadata/2026/01/02.json"
+        assert client.head_object.call_args.kwargs["Bucket"] == "test-bucket"
+
+    def test_non_404_client_error_propagates(self):
+        """A 403 means we could not determine the answer — do not publish over it."""
+        client = make_r2_client(published=False)
+        client.head_object.side_effect = ClientError(
+            {"Error": {"Code": "403", "Message": "Forbidden"},
+             "ResponseMetadata": {"HTTPStatusCode": 403}},
+            "HeadObject",
+        )
+        with pytest.raises(ClientError):
+            self._upload(client)
+        assert client.put_object.call_count == 0
+
+
+class TestCacheControlHeaders:
+    def test_date_keys_are_immutable_and_shared_cacheable(self):
+        client = make_r2_client()
+        with patch("upload._get_client", return_value=client):
+            upload(
+                original_bytes=b"o", stylized_bytes=b"s",
+                metadata={"title": "T"}, bucket="b", today=date(2026, 1, 2),
+                variants={"webp": b"w"}, stripped_bytes=b"x",
+                manifest={"date": "2026-01-02"}, metadata_sig=b"sig",
+            )
+        for call in client.put_object.call_args_list:
+            if call.kwargs["Key"] == "latest.json":
+                continue
+            assert call.kwargs["CacheControl"] == IMMUTABLE_CACHE
+
+    def test_immutable_header_matches_the_worker_constant(self):
+        """The Worker prefers R2's stored header, so a drift here is what ships.
+
+        worker/src/index.ts declares the same string; if these diverge the
+        Worker's constant becomes unreachable for pipeline-written objects and
+        the served header is silently whatever upload.py wrote.
+        """
+        worker_src = (
+            Path(__file__).resolve().parent.parent / "worker" / "src" / "index.ts"
+        ).read_text(encoding="utf-8")
+        match = re.search(r'const IMMUTABLE_CACHE = "([^"]+)"', worker_src)
+        assert match, "IMMUTABLE_CACHE not found in worker/src/index.ts"
+        assert match.group(1) == IMMUTABLE_CACHE
+
+    def test_latest_pointer_is_short_lived(self):
+        client = make_r2_client()
+        with patch("upload._get_client", return_value=client):
+            upload(
+                original_bytes=b"o", stylized_bytes=b"s",
+                metadata={"title": "T"}, bucket="b", today=date(2026, 1, 2),
+            )
+        latest = [c for c in client.put_object.call_args_list
+                  if c.kwargs["Key"] == "latest.json"][0]
+        assert latest.kwargs["CacheControl"] == LATEST_CACHE
+
+
+class TestUtcToday:
+    """The publish date must not depend on the runner's timezone."""
+
+    def test_uses_utc_not_local_time(self):
+        """22:00 UTC is already the next day in UTC+... and still 'today' here."""
+        with patch("upload.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 1, 2, 22, 0, tzinfo=UTC)
+            assert utc_today() == date(2026, 1, 2)
+        mock_dt.now.assert_called_once_with(UTC)
+
+    def test_pacific_evening_still_reports_the_utc_date(self):
+        """8 PM PT on Jan 1 is 04:00 UTC on Jan 2 — the publish date is Jan 2.
+
+        This is the self-hosted Mac Mini case: local date.today() there would
+        say Jan 1 and overwrite the previous day's keys.
+        """
+        with patch("upload.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 1, 2, 4, 0, tzinfo=UTC)
+            assert utc_today() == date(2026, 1, 2)
+
+    def test_upload_defaults_to_utc_today(self):
+        client = make_r2_client()
+        with patch("upload._get_client", return_value=client), \
+             patch("upload.utc_today", return_value=date(2026, 3, 4)):
+            keys = upload(
+                original_bytes=b"o", stylized_bytes=b"s",
+                metadata={"title": "T"}, bucket="b",
+            )
+        assert keys["stylized"] == "stylized/2026/03/04.jpg"
+
+    def test_prepare_metadata_defaults_to_utc_today(self):
+        with patch("upload.utc_today", return_value=date(2026, 3, 4)):
+            prepared = prepare_metadata_for_upload({"title": "T"})
+        assert prepared["date"] == "2026-03-04"

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -41,8 +41,8 @@ class TestGenerateVariants:
         variants = generate_variants(img)
         assert len(variants["webp"]) < jpeg_size
 
-    def test_empty_dict_on_error(self, monkeypatch):
-        """If both formats fail, returns whatever succeeded."""
+    def test_failed_encoders_are_omitted_not_fatal(self, monkeypatch):
+        """A failing encoder drops that variant; the rest still encode."""
 
         original_save = Image.Image.save
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -44,6 +44,22 @@ const FORMAT_CONTENT_TYPE: Record<ImageFormat, string> = {
   jpeg: "image/jpeg",
 };
 
+/** Values `?format=` accepts. Anything else is a client error, not a fallback. */
+const FORMAT_PARAMS = new Set(["avif", "webp", "jpeg", "auto"]);
+
+/**
+ * True when `?format=` is present but not a value we support.
+ *
+ * Silently negotiating past a bad value made `?format=png` and `?format=jpg`
+ * indistinguishable from `?format=auto`, so a typo in a caller's code looked
+ * like it worked and quietly served something else.
+ */
+export function hasInvalidFormat(url: URL): boolean {
+  const param = url.searchParams.get("format");
+  if (param === null) return false;
+  return !FORMAT_PARAMS.has(param.toLowerCase());
+}
+
 export function negotiateFormat(request: Request, url: URL): ImageFormat {
   const param = url.searchParams.get("format")?.toLowerCase();
   if (param === "avif") return "avif";
@@ -311,11 +327,26 @@ function etagMatches(ifNoneMatch: string, httpEtag: string): boolean {
     .some((e) => normalizeEtag(e) === target);
 }
 
-/** Cache-control for date-specific resources — immutable since content never changes. */
+/**
+ * Cache-control for date-specific resources — immutable because the pipeline
+ * publishes a date once and refuses to rewrite it (see _assert_unpublished in
+ * src/upload.py). Kept byte-identical to IMMUTABLE_CACHE in src/upload.py: R2
+ * stores that value on the object and it is preferred over this constant, so
+ * this is only the fallback for objects written by something other than the
+ * pipeline.
+ */
 const IMMUTABLE_CACHE = "public, max-age=31536000, s-maxage=31536000, immutable";
 
-/** Cache-control for /api/today* — short-lived since it resolves to a new date each day. */
-const TODAY_CACHE = "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800";
+/**
+ * Cache-control for /api/today* — this resolves to a new date every morning.
+ *
+ * s-maxage must stay below the publish interval. At the old 86400 an edge PoP
+ * that filled its cache shortly before the 04:00 UTC run kept serving the
+ * previous day's artwork for a further 24 hours, so viewers behind that PoP
+ * never saw a day's art at all. One hour bounds the staleness while still
+ * absorbing the overwhelming majority of traffic.
+ */
+const TODAY_CACHE = "public, max-age=300, s-maxage=3600, stale-while-revalidate=604800";
 
 /** Builds the shared response headers for image endpoints. */
 function buildImageHeaders(
@@ -357,18 +388,36 @@ function jsonResponse(obj: R2ObjectBody, today = false): Response {
   return new Response(obj.body, { headers });
 }
 
-function notModified(etag: string): Response {
+function notModified(etag: string, today = false): Response {
+  // A 304 that omits Cache-Control and Vary invites caches to fall back to
+  // their own heuristics for how long the stored copy stays fresh, and to
+  // ignore that these resources are content-negotiated on Accept. Both must
+  // match what the corresponding 200 would have said.
   return new Response(null, {
     status: 304,
-    headers: { "ETag": etag, ...corsHeaders() },
+    headers: {
+      "ETag": etag,
+      "Cache-Control": today ? TODAY_CACHE : IMMUTABLE_CACHE,
+      "Vary": "Accept",
+      ...corsHeaders(),
+    },
+  });
+}
+
+/** JSON error with CORS — the single shape every non-telemetry failure uses. */
+function errorResponse(status: number, msg: string, cacheControl = "no-store"): Response {
+  return new Response(JSON.stringify({ error: msg }), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": cacheControl,
+      ...corsHeaders(),
+    },
   });
 }
 
 function notFound(msg: string): Response {
-  return new Response(JSON.stringify({ error: msg }), {
-    status: 404,
-    headers: { "Content-Type": "application/json", ...corsHeaders() },
-  });
+  return errorResponse(404, msg);
 }
 
 /**
@@ -393,7 +442,7 @@ async function serveImage(
     const headResult = await headImageObject(bucket, basePath, format, progressive, strip);
     if (!headResult) return notFound(notFoundMsg);
     if (ifNoneMatch && etagMatches(ifNoneMatch, headResult.head.httpEtag)) {
-      return notModified(headResult.head.httpEtag);
+      return notModified(headResult.head.httpEtag, today);
     }
     if (isHead) {
       const headers = buildImageHeaders(
@@ -435,7 +484,7 @@ async function serveJson(
     const head = await bucket.head(key);
     if (!head) return notFound(notFoundMsg);
     if (ifNoneMatch && etagMatches(ifNoneMatch, head.httpEtag)) {
-      return notModified(head.httpEtag);
+      return notModified(head.httpEtag, today);
     }
     if (isHead) {
       const headers: Record<string, string> = {
@@ -456,16 +505,47 @@ async function serveJson(
   return jsonResponse(obj, today);
 }
 
+/**
+ * Serves a non-JSON, non-image object (currently the detached PGP signature)
+ * with the same conditional-request handling as the other endpoints.
+ */
+async function serveBinary(
+  request: Request,
+  bucket: R2Bucket,
+  key: string,
+  contentType: string,
+  notFoundMsg: string,
+  isHead = false,
+): Promise<Response> {
+  const ifNoneMatch = request.headers.get("If-None-Match");
+
+  const headers = (etag: string | undefined): Record<string, string> => {
+    const h: Record<string, string> = {
+      "Content-Type": contentType,
+      "Cache-Control": IMMUTABLE_CACHE,
+      ...corsHeaders(),
+    };
+    if (etag) h["ETag"] = etag;
+    return h;
+  };
+
+  if (isHead || ifNoneMatch) {
+    const head = await bucket.head(key);
+    if (!head) return notFound(notFoundMsg);
+    if (ifNoneMatch && etagMatches(ifNoneMatch, head.httpEtag)) {
+      return notModified(head.httpEtag);
+    }
+    if (isHead) return new Response(null, { status: 200, headers: headers(head.httpEtag) });
+  }
+
+  const obj = await bucket.get(key);
+  if (!obj) return notFound(notFoundMsg);
+  return new Response(obj.body, { headers: headers(obj.httpEtag) });
+}
+
 /** 503 for upstream failures — same JSON+CORS shape as notFound(). */
 function unavailable(msg: string): Response {
-  return new Response(JSON.stringify({ error: msg }), {
-    status: 503,
-    headers: {
-      "Content-Type": "application/json",
-      "Cache-Control": "no-store",
-      ...corsHeaders(),
-    },
-  });
+  return errorResponse(503, msg);
 }
 
 /** Raised when latest.json is missing, to separate "not published yet" from a genuine R2 fault. */
@@ -507,7 +587,49 @@ async function handle(request: Request, env: Env): Promise<Response> {
     const isHead = request.method === "HEAD";
 
     if (request.method !== "GET" && !isHead) {
-      return new Response("Method not allowed", { status: 405 });
+      return errorResponse(405, "Method not allowed");
+    }
+
+    // GET /api/health → publish freshness, for an external uptime monitor.
+    //
+    // The failure mode with no signal at all is the cron simply not running:
+    // GitHub disables scheduled workflows after 60 days of repo inactivity,
+    // and a skipped or failed schedule produces no run, so the ntfy hooks in
+    // generate.yml never fire. Staleness measured at the serving end catches
+    // that, plus R2 write failures and publish bugs, in one probe.
+    if (path === "/api/health") {
+      let today: string;
+      try {
+        today = await getToday(env.BUCKET);
+      } catch (err) {
+        // Never published, or R2 is down — either way this probe must report
+        // unhealthy rather than the 404 the generic handler would produce.
+        const reason = err instanceof NoLatestError ? "no artwork published" : "storage unavailable";
+        return new Response(JSON.stringify({ status: "unhealthy", error: reason }), {
+          status: 503,
+          headers: { "Content-Type": "application/json", "Cache-Control": "no-store", ...corsHeaders() },
+        });
+      }
+      const publishedMs = Date.parse(`${today}T00:00:00Z`);
+      const staleDays = Number.isNaN(publishedMs)
+        ? null
+        : Math.floor((Date.now() - publishedMs) / 86_400_000);
+      const healthy = staleDays !== null && staleDays <= 1;
+      return new Response(
+        JSON.stringify({ status: healthy ? "ok" : "stale", date: today, stale_days: staleDays }),
+        {
+          status: healthy ? 200 : 503,
+          headers: {
+            "Content-Type": "application/json",
+            "Cache-Control": "no-store",
+            ...corsHeaders(),
+          },
+        },
+      );
+    }
+
+    if (hasInvalidFormat(url)) {
+      return errorResponse(400, "Unsupported format. Use avif, webp, jpeg, or auto");
     }
 
     const format = negotiateFormat(request, url);
@@ -534,6 +656,23 @@ async function handle(request: Request, env: Env): Promise<Response> {
     const manifestMatch = path.match(/^\/api\/(\d{4}-\d{2}-\d{2})\.manifest\.json$/);
     if (manifestMatch) {
       return serveJson(request, env.BUCKET, `manifests/${datePath(manifestMatch[1])}.json`, false, `No manifest for ${manifestMatch[1]}`, isHead);
+    }
+
+    // GET|HEAD /api/:date.json.sig → detached PGP signature over the metadata
+    //
+    // The pipeline has always been able to upload this object, but nothing
+    // served it, so a published signature could never actually be fetched and
+    // checked — signing was unverifiable by construction.
+    const sigMatch = path.match(/^\/api\/(\d{4}-\d{2}-\d{2})\.json\.sig$/);
+    if (sigMatch) {
+      return serveBinary(
+        request,
+        env.BUCKET,
+        `metadata/${datePath(sigMatch[1])}.json.sig`,
+        "application/pgp-signature",
+        `No signature for ${sigMatch[1]}`,
+        isHead,
+      );
     }
 
     // GET|HEAD /api/:date.json → metadata for date

--- a/worker/test/index.test.ts
+++ b/worker/test/index.test.ts
@@ -902,3 +902,86 @@ describe("HEAD method support", () => {
     expect(res.headers.get("Accept-CH")).toBe("DPR, Width, Viewport-Width");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Cache-Control contract
+// ---------------------------------------------------------------------------
+
+describe("cache headers", () => {
+  const TODAY = "2026-01-02";
+
+  function env(objects: Record<string, R2ObjectBody | undefined>) {
+    return {
+      BUCKET: makeBucket({
+        "latest.json": fakeR2Body({ date: TODAY }),
+        ...objects,
+      }),
+      WEB_VITALS: { writeDataPoint() {} } as unknown as AnalyticsEngineDataset,
+      WEB_ERRORS: { writeDataPoint() {} } as unknown as AnalyticsEngineDataset,
+      ALLOWED_ORIGINS: "",
+    };
+  }
+
+  // s-maxage must stay under the 24h publish interval. At 86400 an edge PoP
+  // that filled shortly before the 04:00 UTC run kept serving the previous
+  // day's artwork for another full day.
+  it("keeps /api/today shared-cacheable for less than a publish interval", async () => {
+    const e = env({ "stylized/2026/01/02.jpg": fakeR2Body("img", "image/jpeg") });
+    const res = await worker.fetch(makeRequest("/api/today"), e);
+    const cc = res.headers.get("Cache-Control")!;
+
+    const sMaxAge = Number(/s-maxage=(\d+)/.exec(cc)?.[1]);
+    expect(sMaxAge).toBeLessThan(86400);
+    expect(cc).not.toContain("immutable");
+  });
+
+  // The Worker prefers the header R2 stored on the object, so its own constant
+  // is only a fallback. Fixtures used to leave httpMetadata.cacheControl unset,
+  // which meant the tests exercised the fallback exclusively and a divergence
+  // between the pipeline's header and this one could not be observed.
+  it("prefers the Cache-Control stored on the object for dated routes", async () => {
+    // Deliberately unlike IMMUTABLE_CACHE: if this matched the fallback, the
+    // assertion would hold whichever branch ran and prove nothing.
+    const stored = "public, max-age=42, s-maxage=42";
+    const obj = fakeR2Body("img", "image/jpeg");
+    (obj as unknown as { httpMetadata: R2HTTPMetadata }).httpMetadata = {
+      contentType: "image/jpeg",
+      cacheControl: stored,
+    } as R2HTTPMetadata;
+
+    const e = env({ "stylized/2026/01/02.jpg": obj });
+    const res = await worker.fetch(makeRequest(`/api/${TODAY}`), e);
+    expect(res.headers.get("Cache-Control")).toBe(stored);
+  });
+
+  it("falls back to its own immutable constant when R2 stored none", async () => {
+    const e = env({ "stylized/2025/12/25.jpg": fakeR2Body("img", "image/jpeg") });
+    const res = await worker.fetch(makeRequest("/api/2025-12-25"), e);
+    expect(res.headers.get("Cache-Control")).toContain("immutable");
+  });
+
+  // A 304 with no Cache-Control lets a cache substitute its own heuristic for
+  // how long the stored copy stays fresh, and no Vary loses the fact that the
+  // resource is negotiated on Accept.
+  it("carries Cache-Control and Vary on a 304", async () => {
+    const obj = fakeR2Body("img", "image/jpeg", '"abc123"');
+    const e = env({ "stylized/2026/01/02.jpg": obj });
+    const res = await worker.fetch(
+      new Request("https://example.com/api/today", { headers: { "If-None-Match": '"abc123"' } }),
+      e,
+    );
+    expect(res.status).toBe(304);
+    expect(res.headers.get("Cache-Control")).toBeTruthy();
+    expect(res.headers.get("Vary")).toBe("Accept");
+  });
+
+  it("uses the today policy on a 304 for /api/today, not the immutable one", async () => {
+    const obj = fakeR2Body("img", "image/jpeg", '"abc123"');
+    const e = env({ "stylized/2026/01/02.jpg": obj });
+    const res = await worker.fetch(
+      new Request("https://example.com/api/today", { headers: { "If-None-Match": '"abc123"' } }),
+      e,
+    );
+    expect(res.headers.get("Cache-Control")).not.toContain("immutable");
+  });
+});

--- a/worker/test/unit-helpers.test.ts
+++ b/worker/test/unit-helpers.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import worker, { classifyUA, getAllowedOrigins, isProgressive, isStrip } from "../src/index";
+import worker, {
+  classifyUA,
+  getAllowedOrigins,
+  hasInvalidFormat,
+  isProgressive,
+  isStrip,
+} from "../src/index";
 
 describe("worker helper utilities", () => {
   it("detects mobile user agents", () => {
@@ -95,5 +101,218 @@ describe("upstream failure handling", () => {
   it("does not mask a genuine R2 fault as a 404", async () => {
     const res = await worker.fetch(new Request(`https://x/api/2026-01-02`), brokenBucket);
     expect(res.status).toBe(503);
+  });
+});
+
+describe("format parameter validation", () => {
+  it("accepts the supported values", () => {
+    for (const value of ["avif", "webp", "jpeg", "auto", "AVIF", "Auto"]) {
+      expect(hasInvalidFormat(new URL(`https://x/api/today?format=${value}`))).toBe(false);
+    }
+  });
+
+  it("accepts an absent format parameter", () => {
+    expect(hasInvalidFormat(new URL("https://x/api/today"))).toBe(false);
+  });
+
+  // A typo used to fall through to Accept negotiation, so ?format=png behaved
+  // exactly like ?format=auto and the caller never learned it was ignored.
+  it("rejects unsupported values", () => {
+    for (const value of ["png", "jpg", "gif", ""]) {
+      expect(hasInvalidFormat(new URL(`https://x/api/today?format=${value}`))).toBe(true);
+    }
+  });
+});
+
+describe("response contract", () => {
+  function envWith(bucket: Partial<R2Bucket>) {
+    return {
+      BUCKET: bucket as R2Bucket,
+      WEB_VITALS: { writeDataPoint() {} } as unknown as AnalyticsEngineDataset,
+      WEB_ERRORS: { writeDataPoint() {} } as unknown as AnalyticsEngineDataset,
+      ALLOWED_ORIGINS: "",
+    };
+  }
+
+  const emptyBucket = envWith({ get: async () => null, head: async () => null });
+
+  // 405 used to be text/plain with no CORS headers, so a browser saw an opaque
+  // CORS error rather than the JSON shape every other failure returns.
+  it("returns 405 as JSON with CORS", async () => {
+    const res = await worker.fetch(
+      new Request("https://x/api/today", { method: "DELETE" }),
+      emptyBucket,
+    );
+    expect(res.status).toBe(405);
+    expect(res.headers.get("Content-Type")).toBe("application/json");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(await res.json()).toEqual({ error: "Method not allowed" });
+  });
+
+  it("returns 400 with CORS for an unsupported format", async () => {
+    const res = await worker.fetch(new Request("https://x/api/today?format=png"), emptyBucket);
+    expect(res.status).toBe(400);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(await res.json()).toEqual({
+      error: "Unsupported format. Use avif, webp, jpeg, or auto",
+    });
+  });
+
+  it("validates format before resolving the date, so a bad format never hits R2", async () => {
+    let reads = 0;
+    const counting = envWith({
+      get: async () => {
+        reads += 1;
+        return null;
+      },
+      head: async () => null,
+    });
+    await worker.fetch(new Request("https://x/api/today?format=png"), counting);
+    expect(reads).toBe(0);
+  });
+
+  it("returns 404 as no-store so a later publish is visible", async () => {
+    const res = await worker.fetch(new Request("https://x/api/today"), emptyBucket);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+});
+
+describe("health endpoint", () => {
+  function envWith(bucket: Partial<R2Bucket>) {
+    return {
+      BUCKET: bucket as R2Bucket,
+      WEB_VITALS: { writeDataPoint() {} } as unknown as AnalyticsEngineDataset,
+      WEB_ERRORS: { writeDataPoint() {} } as unknown as AnalyticsEngineDataset,
+      ALLOWED_ORIGINS: "",
+    };
+  }
+
+  function bucketWithLatest(dateStr: string) {
+    return envWith({
+      get: async (key: string) =>
+        key === "latest.json"
+          ? ({ json: async () => ({ date: dateStr }) } as unknown as R2ObjectBody)
+          : null,
+      head: async () => null,
+    });
+  }
+
+  function isoDaysAgo(days: number): string {
+    return new Date(Date.now() - days * 86_400_000).toISOString().slice(0, 10);
+  }
+
+  it("reports ok for artwork published today", async () => {
+    const res = await worker.fetch(new Request("https://x/api/health"), bucketWithLatest(isoDaysAgo(0)));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ status: "ok", stale_days: 0 });
+  });
+
+  it("tolerates one day of lag, since the cron runs at 04:00 UTC", async () => {
+    const res = await worker.fetch(new Request("https://x/api/health"), bucketWithLatest(isoDaysAgo(1)));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ status: "ok", stale_days: 1 });
+  });
+
+  // The failure this endpoint exists for: the cron silently stopped running,
+  // which produces no workflow run and therefore no ntfy notification.
+  it("reports stale with a 503 once publishing falls behind", async () => {
+    const res = await worker.fetch(new Request("https://x/api/health"), bucketWithLatest(isoDaysAgo(3)));
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({ status: "stale", stale_days: 3 });
+  });
+
+  it("reports unhealthy when nothing has been published", async () => {
+    const res = await worker.fetch(
+      new Request("https://x/api/health"),
+      envWith({ get: async () => null, head: async () => null }),
+    );
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ status: "unhealthy", error: "no artwork published" });
+  });
+
+  it("reports unhealthy when R2 is down", async () => {
+    const res = await worker.fetch(
+      new Request("https://x/api/health"),
+      envWith({
+        get: async () => {
+          throw new Error("R2 is down");
+        },
+        head: async () => null,
+      }),
+    );
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ status: "unhealthy", error: "storage unavailable" });
+  });
+
+  it("is never cached", async () => {
+    const res = await worker.fetch(new Request("https://x/api/health"), bucketWithLatest(isoDaysAgo(0)));
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});
+
+describe("metadata signature route", () => {
+  function envWith(objects: Record<string, unknown>) {
+    return {
+      BUCKET: {
+        get: async (key: string) => objects[key] ?? null,
+        head: async (key: string) =>
+          objects[key] ? ({ httpEtag: '"sig-etag"' } as unknown as R2Object) : null,
+      } as unknown as R2Bucket,
+      WEB_VITALS: { writeDataPoint() {} } as unknown as AnalyticsEngineDataset,
+      WEB_ERRORS: { writeDataPoint() {} } as unknown as AnalyticsEngineDataset,
+      ALLOWED_ORIGINS: "",
+    };
+  }
+
+  const SIG = "-----BEGIN PGP SIGNATURE-----\nabc\n-----END PGP SIGNATURE-----\n";
+
+  function sigObject() {
+    return {
+      httpEtag: '"sig-etag"',
+      body: new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode(SIG));
+          c.close();
+        },
+      }),
+    };
+  }
+
+  // The pipeline could always upload metadata/<date>.json.sig, but no route
+  // served it, so a signature could never be fetched and verified.
+  it("serves the detached signature for a date", async () => {
+    const env = envWith({ "metadata/2026/01/02.json.sig": sigObject() });
+    const res = await worker.fetch(new Request("https://x/api/2026-01-02.json.sig"), env);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/pgp-signature");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(await res.text()).toBe(SIG);
+  });
+
+  it("404s with CORS when a date has no signature", async () => {
+    const res = await worker.fetch(new Request("https://x/api/2026-01-02.json.sig"), envWith({}));
+    expect(res.status).toBe(404);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(await res.json()).toEqual({ error: "No signature for 2026-01-02" });
+  });
+
+  it("does not shadow the plain metadata route", async () => {
+    const env = envWith({ "metadata/2026/01/02.json.sig": sigObject() });
+    const res = await worker.fetch(new Request("https://x/api/2026-01-02.json"), env);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "No metadata for 2026-01-02" });
+  });
+
+  it("supports conditional requests", async () => {
+    const env = envWith({ "metadata/2026/01/02.json.sig": sigObject() });
+    const res = await worker.fetch(
+      new Request("https://x/api/2026-01-02.json.sig", {
+        headers: { "If-None-Match": '"sig-etag"' },
+      }),
+      env,
+    );
+    expect(res.status).toBe(304);
   });
 });


### PR DESCRIPTION
Second-pass review of `main` after the audit closed out, run as an architecture review and a line-by-line walkthrough in parallel. The audit fixed the obvious defects; this is the tier underneath — places where the system makes a promise it does not keep.

## Publishing integrity

**Date keys were `immutable` but mutable.** Every date-keyed object ships `public, max-age=31536000, immutable` — a promise the bytes never change. A same-day manual dispatch rewrote them. Because uploads land key-by-key rather than atomically, a client fetching mid-rewrite could end up holding one artwork's image beside another artwork's metadata *permanently*, since `immutable` tells it never to revalidate.

Publishing is now write-once: `upload()` HEADs the date's metadata key and refuses unless `--overwrite` is passed. The check runs before the first PUT, so a refusal writes nothing. Both generate workflows expose `overwrite` as a dispatch input — including the self-hosted one, which would otherwise have no way to proceed on a day the cron already ran.

**The publish date was the runner's local date.** Hosted runners are UTC, but `generate-self-hosted.yml` runs the same code on a Pacific-time Mac Mini. An evening dispatch there — including 8 PM PT, the time the README advertises — computed *yesterday's* date, overwrote that day's keys, and rewound `latest.json`. Now `datetime.now(UTC).date()` everywhere a publish date is derived.

## Cache honesty

- **`/api/today` held for a day at the edge.** `s-maxage=86400` against a 24-hour publish cadence meant a PoP that filled shortly before the 04:00 run kept serving the previous day's artwork for another full day — viewers behind it never saw that day's art. Now `3600`.
- **The documented `Cache-Control` was never served.** The Worker prefers the header stored on the R2 object and only falls back to its own constant, but `upload.py` wrote a *different* string (no `s-maxage`). The pipeline's value is what shipped; the Worker's constant was unreachable for every pipeline-written key, and the README documented the unreachable one. Both sides now write the same string, and a test asserts they stay byte-identical.
- **304s** now carry `Cache-Control` and `Vary`, matching the 200 they stand in for.

## Signing was doubly broken

- **It never engaged.** Gated on `GPG_KEY_ID or GPG_PASSPHRASE`, while the README's own recipe (`gpg --quick-generate-key … never`) produces a passphrase-less default key with neither. Following the documentation exactly imported a key and then silently never signed with it. Now `GPG_PRIVATE_KEY` alone is sufficient.
- **It was unverifiable.** The pipeline could always upload the detached signature to `metadata/YYYY/MM/DD.json.sig`, but no route served it — a published signature could never be fetched and checked. Added `GET /api/:date.json.sig`, with a `gpg --verify` recipe in the README.

This closes out the open question about whether to add the route; signing is now a complete feature rather than a half-built one.

## Model weights had no integrity check

`urlretrieve` reports success for a truncated body, and both generate workflows cached `models/weights` under the constant key `adain-models-v1`. One corrupt download would be cached and replayed into every subsequent run, failing `torch.load` nightly with no self-heal path — a human would have had to manually evict the Actions cache.

SHA-256 is now pinned per file and verified both on download and on every run; cache keys derive from the download script so changing a pin evicts the old entry. Both pins were verified against the upstream release, and a truncated file was confirmed to trigger re-download. Verification costs 0.35 s for 94 MB.

## Resilience and ergonomics

- **Retries back off** exponentially with jitter. Ten attempts previously burned in about two seconds, giving a struggling upstream no time to recover — observed directly while testing. Content rejections (NSFW title, quality gate) still retry immediately; nothing upstream needs to recover from those.
- **`--source` defaults to `met`.** It defaulted to `unsplash`, so the README's first documented command died on a missing API key — while the README led with "no API key sits on the critical path" and both workflows overrode it to `met`. A missing key now explains itself instead of raising a bare `KeyError`.
- **`GET /api/health`** reports publish staleness. The failure mode with no signal at all is the cron simply not running: GitHub disables schedules after 60 days of repo inactivity, and a skipped run fires no ntfy notification. Point any uptime monitor at it.
- **405 and unknown `?format=`** return JSON with CORS. `?format=png` was silently treated as `auto`, so a typo looked like it worked.

## Tests: 200 → 245 Python, 81 → 103 Worker

Three existing tests passed for the wrong reason:

- `main()` had **no test at all**, despite owning the pipeline's ordering, gating and plumbing. 15 now cover it, hermetic against a polluted shell environment (verified by running with `GPG_KEY_ID` and `STYLE_MODE` exported).
- `TestMaxSizeCLIArg` built a throwaway `ArgumentParser` with the default duplicated inline — it asserted `1920` while the real default was `1280`, and would have passed with `--max-size` deleted from the CLI entirely.
- `test_all_sources_valid` caught `Exception`, swallowing the very `ValueError` it claimed to check, while making up to 30 live HTTP requests per CI run.
- Worker fixtures never populated `httpMetadata.cacheControl`, so the stored-header branch was structurally untestable — which is why the header mismatch above could survive a green suite.

Each fix was checked to fail against the old code before being kept.

## Also

Removed the dead `MODELS_CACHE` env var and fixed `UV_CACHE_DIR`, which used a tilde that `env:` does not expand (it would have created a directory named `~`). Documented `METRICS_OUT`, `METRICS_LABEL`, `NTFY_TOPIC`. Dropped the phantom `.avif`/`.webp` routes and a stale duplicate query-parameter table from the README. Devcontainer fetches models on create.

## Verification

`245 pytest`, `103 worker tests`, `ruff` clean, `uv lock --check` clean, `actionlint` clean, `tsc --noEmit` clean, `wrangler deploy --dry-run` resolves all bindings. Checksum pins validated against the real upstream assets. All six CI jobs green — including the Podman smoke, which does a live Met fetch and so exercises the new default and the backoff against the real API.

The museum APIs and `workers.dev` are proxy-blocked in the dev sandbox (403 CONNECT), so the live end-to-end path was verified in CI rather than locally.

## Deliberately not done

- **No config layer refactor.** Env vars are still read across four files and the low-memory profile is still implemented twice. Worth a single frozen `Config` built once at the top of `main()`, but it touches every module and belongs in its own change.
- **No `src/` package restructure.** Still a flat non-package on `sys.path` with maximally generic module names (`fetch`, `quality`, `upload`).
- **No `met` → `artic` fallback.** The sources are interchangeable and a hard failure of one kills the run; backoff mitigates but does not fix this.
- **Two variant dialects remain** — `metadata.variants` uses MIME types, the manifest uses short names, for the same concept.
- **`StyleTransfer.transfer()`'s `alpha_mode` parameter is still dead**; `main()` builds its own mask.