### PR TITLE
Stop scheduled runs failing on a date a dispatch already published

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -76,12 +76,19 @@ jobs:
       # so those runs produce source-dependent output).
       - name: Generate and upload
         run: |
-          uv run python src/main.py --source "${SOURCE}" ${OVERWRITE:+--overwrite}
+          uv run python src/main.py --source "${SOURCE}" \
+            ${OVERWRITE:+--overwrite} ${SKIP_IF_PUBLISHED:+--skip-if-published}
         env:
           SOURCE: ${{ inputs.source || 'met' }}
           # Empty unless the dispatch input is checked; ${VAR:+--overwrite}
           # then expands to nothing, so scheduled runs never pass the flag.
           OVERWRITE: ${{ inputs.overwrite && '1' || '' }}
+          # Scheduled runs only. A dispatch after 17:00 PT lands on tomorrow's
+          # UTC date, so the next morning's cron finds the day already
+          # published — a no-op, not a fault, and it must not go red or page.
+          # A manual dispatch that collides still fails loudly: there the
+          # operator asked for a publish and did not get one.
+          SKIP_IF_PUBLISHED: ${{ github.event_name == 'schedule' && '1' || '' }}
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ All `GET` endpoints also support `HEAD` — returns the same response headers (i
 | Endpoint pattern | `Cache-Control` |
 |-----------------|----------------|
 | `/api/today*` | `public, max-age=300, s-maxage=3600, stale-while-revalidate=604800` — short browser TTL since "today" rolls over daily; the edge TTL stays below the 24h publish interval so a PoP cannot serve yesterday's artwork past the next run |
-| `/api/YYYY-MM-DD*` | `public, max-age=31536000, s-maxage=31536000, immutable` — safe because publishing is write-once: the pipeline refuses to rewrite a date unless `--overwrite` is passed |
+| `/api/YYYY-MM-DD*` | `public, max-age=31536000, s-maxage=31536000, immutable` — safe because publishing is write-once: the pipeline refuses to rewrite a date unless `--overwrite` is passed. The check runs twice, once before the fetch so a collision costs nothing and once immediately before the first upload, which is the one that closes the race |
 
 ### Responsive image consumer snippet
 
@@ -235,6 +235,7 @@ just generate --alpha 0.5         # subtle style (0.0-1.0)
 just generate --any-subject       # disable landscape filter
 just generate --max-size 1536     # higher processing resolution
 just generate --overwrite         # republish a date already in R2
+just generate --skip-if-published # exit 0 instead of failing if the date exists
 
 # List all available recipes
 just

--- a/src/main.py
+++ b/src/main.py
@@ -8,10 +8,11 @@ import random
 import socket
 import sys
 import time
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from io import BytesIO
 from math import gcd
 from pathlib import Path
+from typing import NoReturn
 
 from PIL import Image
 from PIL.ExifTags import IFD
@@ -24,6 +25,7 @@ from sign_metadata import sign_metadata
 from stylize import StyleTransfer, gradient_alpha_mask, luminance_alpha_mask
 from upload import (
     AlreadyPublishedError,
+    assert_unpublished,
     prepare_metadata_for_upload,
     serialize_metadata,
     upload,
@@ -301,6 +303,28 @@ def ensure_models():
     subprocess.run([sys.executable, str(script)], check=True)
 
 
+def _exit_already_published(
+    exc: AlreadyPublishedError, today: date, skip_if_published: bool,
+) -> NoReturn:
+    """Terminate a run whose date is already in R2.
+
+    A scheduled run that finds the date published has nothing to do and nothing
+    to report: the day's art exists, which is the whole outcome the schedule
+    exists to produce. Exiting non-zero there turns a benign no-op into a red
+    run and a high-priority failure notification — which is exactly what
+    happened the first morning after publishing became write-once, because an
+    evening dispatch the night before had already claimed the UTC date.
+
+    A manual dispatch is the opposite case. There the collision is a surprise
+    the operator asked to be told about, so it stays an error.
+    """
+    if skip_if_published:
+        print(f"↩ {today.isoformat()} is already published — nothing to do.")
+        sys.exit(0)
+    print(f"\n✗ {exc}", file=sys.stderr)
+    sys.exit(1)
+
+
 def _parse_cli_bool(value: str | None) -> bool:
     """Parse CLI booleans from --flag, --flag=true, or --flag=false."""
     if value is None:
@@ -319,9 +343,16 @@ def build_parser() -> argparse.ArgumentParser:
     # works on a fresh clone, and it matches what both generate workflows run.
     parser.add_argument("--source", default="met", choices=["unsplash", "met", "artic"],
                         help="Art source (default: met)")
-    parser.add_argument("--overwrite", action="store_true",
-                        help="Republish a date that already exists in R2 "
-                             "(date keys are served immutable — see docs)")
+    # Contradictory intents: one insists on publishing over an existing date,
+    # the other stands down for it. Passing both is an operator error.
+    published = parser.add_mutually_exclusive_group()
+    published.add_argument("--overwrite", action="store_true",
+                           help="Republish a date that already exists in R2 "
+                                "(date keys are served immutable — see docs)")
+    published.add_argument("--skip-if-published", action="store_true",
+                           help="Exit 0 without generating when the date is already "
+                                "published, instead of failing. For scheduled runs, "
+                                "where an existing date is a no-op rather than a fault.")
     parser.add_argument("--alpha", type=float, default=0.8,
                         help="Style strength 0.0-1.0 (default: 0.8)")
     parser.add_argument("--alpha-mode", default="uniform",
@@ -419,6 +450,21 @@ def main():
         args.memory_profile,
         args.variants,
     )
+
+    # Capture the run date once, before anything reads it. The preflight below,
+    # the manifest and the upload all have to agree: a run straddling midnight
+    # UTC would otherwise check one date for existing keys and publish another.
+    today = utc_today()
+    today_str = today.isoformat()
+
+    # 0. Preflight the write-once check — see upload.assert_unpublished().
+    if not args.dry_run and not args.overwrite:
+        t = time.perf_counter()
+        try:
+            assert_unpublished(today)
+        except AlreadyPublishedError as exc:
+            _exit_already_published(exc, today, args.skip_if_published)
+        record_timing("preflight", t)
 
     # 1. Fetch CC0 artwork
     quality_gate = not args.skip_quality_check
@@ -538,9 +584,6 @@ def main():
 
     # Add structured license details and variant descriptors
     metadata["license_details"] = build_license_details(metadata)
-    # Capture today once to avoid day-boundary skew between manifest and upload
-    today = utc_today()
-    today_str = today.isoformat()
     metadata["variants"] = build_variants(
         stylized, stylized_bytes,
         original_img, original_bytes,
@@ -655,8 +698,9 @@ def main():
             overwrite=args.overwrite,
         )
     except AlreadyPublishedError as exc:
-        print(f"\n✗ {exc}", file=sys.stderr)
-        sys.exit(1)
+        # Reachable despite the preflight: a concurrent generator can publish
+        # the date in the window between the two checks.
+        _exit_already_published(exc, today, args.skip_if_published)
     record_timing("upload", t)
     print("Uploaded:")
     for name, key in keys.items():

--- a/src/upload.py
+++ b/src/upload.py
@@ -72,6 +72,21 @@ def serialize_metadata(metadata: dict) -> bytes:
     return json.dumps(metadata, indent=2, sort_keys=True).encode()
 
 
+def _is_published(client, bucket: str, date_path: str) -> bool:
+    """Whether the metadata key for a date already exists in R2."""
+    try:
+        client.head_object(Bucket=bucket, Key=f"metadata/{date_path}.json")
+    except ClientError as exc:
+        # 404/NoSuchKey is the expected path: nothing published for this date.
+        status = exc.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+        code = exc.response.get("Error", {}).get("Code")
+        if status == 404 or code in {"404", "NoSuchKey", "NotFound"}:
+            return False
+        raise
+
+    return True
+
+
 def _assert_unpublished(client, bucket: str, date_path: str, today: date) -> None:
     """Refuse to overwrite a date that has already been published.
 
@@ -86,23 +101,28 @@ def _assert_unpublished(client, bucket: str, date_path: str, today: date) -> Non
     (`--overwrite`, or the workflow_dispatch input) to republish a date
     deliberately, accepting that already-cached copies stay stale.
     """
-    key = f"metadata/{date_path}.json"
-    try:
-        client.head_object(Bucket=bucket, Key=key)
-    except ClientError as exc:
-        # 404/NoSuchKey is the expected path: nothing published for this date.
-        status = exc.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
-        code = exc.response.get("Error", {}).get("Code")
-        if status == 404 or code in {"404", "NoSuchKey", "NotFound"}:
-            return
-        raise
+    if _is_published(client, bucket, date_path):
+        raise AlreadyPublishedError(
+            f"{today.isoformat()} is already published "
+            f"(found metadata/{date_path}.json). Date keys are served immutable, "
+            "so rewriting them leaves stale and possibly mismatched copies in "
+            "caches forever. Re-run with --overwrite if that is what you want."
+        )
 
-    raise AlreadyPublishedError(
-        f"{today.isoformat()} is already published (found {key}). "
-        "Date keys are served immutable, so rewriting them leaves stale and "
-        "possibly mismatched copies in caches forever. Re-run with --overwrite "
-        "if that is what you want."
-    )
+
+def assert_unpublished(today: date | None = None, bucket: str | None = None) -> None:
+    """Preflight the write-once check before any expensive work happens.
+
+    upload() runs this same check immediately before its first PUT, and that
+    call is the authoritative one — it is what narrows the window in which a
+    concurrent generator can slip in. This wrapper does not replace it. It
+    exists so that the *common* rejection lands early: without it a collision
+    costs a full fetch → style transfer → variants pipeline, half a minute of
+    work, before anything so much as looks at R2.
+    """
+    bucket = bucket or os.environ.get("R2_BUCKET", "bauhaus")
+    today = today or utc_today()
+    _assert_unpublished(_get_client(), bucket, today.strftime("%Y/%m/%d"), today)
 
 
 def upload(

--- a/tests/test_main_pipeline.py
+++ b/tests/test_main_pipeline.py
@@ -56,6 +56,9 @@ class _Harness:
         self.sign = MagicMock(return_value=b"-----BEGIN PGP SIGNATURE-----")
         self.fetch = MagicMock(return_value=_artwork())
         self.ensure_models = MagicMock()
+        # Default: the date is free. Give it a side_effect of
+        # AlreadyPublishedError to exercise the preflight rejection.
+        self.assert_unpublished = MagicMock()
 
     def __enter__(self):
         style_img = Image.new("RGB", (256, 256), (200, 60, 40))
@@ -78,6 +81,7 @@ class _Harness:
             patch.object(main_mod, "ensure_models", self.ensure_models),
             patch.object(main_mod, "StyleTransfer", MagicMock(return_value=transfer)),
             patch.object(main_mod, "upload", self.upload),
+            patch.object(main_mod, "assert_unpublished", self.assert_unpublished),
             patch.object(main_mod, "sign_metadata", self.sign),
             patch.object(main_mod, "utc_today", return_value=date(2026, 1, 2)),
         ]
@@ -149,6 +153,89 @@ class TestMainOrchestration:
             with pytest.raises(SystemExit) as exc:
                 main_mod.main()
         assert exc.value.code == 1
+
+
+class TestPreflight:
+    """The write-once check runs before the work, not after it.
+
+    upload() still holds the authoritative check — it is what narrows the race
+    window — but reaching it costs a fetch, a style transfer and a full variant
+    encode. On a collision all of that is thrown away.
+    """
+
+    def test_preflight_runs_before_the_fetch(self):
+        with _Harness([]) as h:
+            h.assert_unpublished.side_effect = AlreadyPublishedError("2026-01-02 …")
+            with pytest.raises(SystemExit):
+                main_mod.main()
+        assert h.fetch.call_count == 0
+        assert h.upload.call_count == 0
+
+    def test_preflight_uses_the_same_date_as_the_upload(self):
+        """One date for both checks, or a run across midnight UTC publishes over itself."""
+        with _Harness([]) as h:
+            main_mod.main()
+        assert h.assert_unpublished.call_args.args[0] == date(2026, 1, 2)
+        assert h.upload.call_args.kwargs["today"] == date(2026, 1, 2)
+
+    def test_overwrite_skips_the_preflight(self):
+        """--overwrite means publish regardless; asking R2 first proves nothing."""
+        with _Harness(["--overwrite"]) as h:
+            main_mod.main()
+        assert h.assert_unpublished.call_count == 0
+        assert h.upload.call_count == 1
+
+    def test_dry_run_never_touches_r2(self, tmp_path):
+        """A dry run has no R2 credentials to preflight with."""
+        with _Harness(["--dry-run"]) as h, patch.object(main_mod, "OUTPUT_DIR", tmp_path):
+            main_mod.main()
+        assert h.assert_unpublished.call_count == 0
+
+
+class TestSkipIfPublished:
+    """A scheduled run that finds the date published is a no-op, not a failure.
+
+    The morning after publishing became write-once, an evening dispatch had
+    already claimed the UTC date and the cron run went red — a red X and a
+    high-priority page for a day whose art existed and was being served.
+    """
+
+    def test_skip_exits_zero_on_preflight_collision(self):
+        with _Harness(["--skip-if-published"]) as h:
+            h.assert_unpublished.side_effect = AlreadyPublishedError("2026-01-02 …")
+            with pytest.raises(SystemExit) as exc:
+                main_mod.main()
+        assert exc.value.code == 0
+        assert h.upload.call_count == 0
+
+    def test_skip_exits_zero_when_upload_loses_the_race(self):
+        """The preflight can pass and a concurrent generator still win."""
+        with _Harness(["--skip-if-published"]) as h:
+            h.upload.side_effect = AlreadyPublishedError("2026-01-02 …")
+            with pytest.raises(SystemExit) as exc:
+                main_mod.main()
+        assert exc.value.code == 0
+
+    def test_without_the_flag_a_collision_still_fails(self):
+        """A manual dispatch asked for a publish; not getting one is an error."""
+        with _Harness([]) as h:
+            h.assert_unpublished.side_effect = AlreadyPublishedError("2026-01-02 …")
+            with pytest.raises(SystemExit) as exc:
+                main_mod.main()
+        assert exc.value.code == 1
+
+    def test_skip_does_not_suppress_an_unpublished_run(self):
+        """The flag only changes the collision path — a free date still publishes."""
+        with _Harness(["--skip-if-published"]) as h:
+            main_mod.main()
+        assert h.upload.call_count == 1
+
+    def test_overwrite_and_skip_are_mutually_exclusive(self):
+        """Contradictory intents: publish over it, versus stand down for it."""
+        with _Harness(["--overwrite", "--skip-if-published"]):
+            with pytest.raises(SystemExit) as exc:
+                main_mod.main()
+        assert exc.value.code == 2
 
     def test_signed_bytes_are_the_uploaded_bytes(self):
         """The signature must cover exactly the JSON that lands in R2."""

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,6 +1,7 @@
 """Tests for upload.py — key generation, metadata enrichment, and S3 calls."""
 
 import json
+import os
 import re
 from datetime import UTC, date, datetime
 from pathlib import Path
@@ -14,6 +15,7 @@ from upload import (
     IMMUTABLE_CACHE,
     LATEST_CACHE,
     AlreadyPublishedError,
+    assert_unpublished,
     prepare_metadata_for_upload,
     serialize_metadata,
     upload,
@@ -401,6 +403,55 @@ class TestWriteOnceGuard:
         with pytest.raises(ClientError):
             self._upload(client)
         assert client.put_object.call_count == 0
+
+
+class TestAssertUnpublishedPreflight:
+    """The public wrapper main.py calls before spending 30s on an image.
+
+    It answers the same question as the guard inside upload(), against the same
+    key, so a preflight that passes and an upload that then refuses can only
+    mean a concurrent generator — never a disagreement between the two checks.
+    """
+
+    def _preflight(self, client, **kwargs):
+        with patch("upload._get_client", return_value=client):
+            return assert_unpublished(today=date(2026, 1, 2), bucket="test-bucket", **kwargs)
+
+    def test_unpublished_date_passes(self):
+        assert self._preflight(make_r2_client(published=False)) is None
+
+    def test_published_date_raises(self):
+        with pytest.raises(AlreadyPublishedError, match="2026-01-02"):
+            self._preflight(make_r2_client(published=True))
+
+    def test_checks_the_same_key_the_upload_guard_checks(self):
+        client = make_r2_client(published=False)
+        self._preflight(client)
+        assert client.head_object.call_args.kwargs["Key"] == "metadata/2026/01/02.json"
+        assert client.head_object.call_args.kwargs["Bucket"] == "test-bucket"
+
+    def test_never_writes(self):
+        client = make_r2_client(published=False)
+        self._preflight(client)
+        assert client.put_object.call_count == 0
+
+    def test_non_404_client_error_propagates(self):
+        """A 403 answers nothing; it must not read as "free to publish"."""
+        client = make_r2_client(published=False)
+        client.head_object.side_effect = ClientError(
+            {"Error": {"Code": "403", "Message": "Forbidden"},
+             "ResponseMetadata": {"HTTPStatusCode": 403}},
+            "HeadObject",
+        )
+        with pytest.raises(ClientError):
+            self._preflight(client)
+
+    def test_bucket_defaults_to_the_environment(self):
+        client = make_r2_client(published=False)
+        with patch("upload._get_client", return_value=client), \
+             patch.dict(os.environ, {"R2_BUCKET": "env-bucket"}):
+            assert_unpublished(today=date(2026, 1, 2))
+        assert client.head_object.call_args.kwargs["Bucket"] == "env-bucket"
 
 
 class TestCacheControlHeaders:


### PR DESCRIPTION
## What happened

The first morning after publishing became write-once (#103), the 04:00 cron went red:

```
✗ 2026-08-01 is already published (found metadata/2026/08/01.json).
  Date keys are served immutable... Re-run with --overwrite if that is what you want.
```

Nothing was broken. A manual dispatch at 02:05 UTC the evening before — 19:05 PT, well inside normal working hours — had already published that UTC date. The scheduled run correctly refused to rewrite immutable keys and exited 1: a red X and a high-priority ntfy page for a day whose art existed and was being served.

## Scheduled runs stand down instead of failing

`--skip-if-published` turns an already-published date into an exit 0 no-op. `generate.yml` passes it only when `github.event_name == 'schedule'`.

For the cron, the day's art existing *is* the outcome it exists to produce, however it got there. A manual dispatch keeps failing loudly — there the operator asked for a publish and did not get one, which is worth interrupting them for. `generate-self-hosted.yml` is dispatch-only and is left alone for the same reason.

The flag is mutually exclusive with `--overwrite`: insisting on publishing over a date and standing down for it are contradictory instructions, so passing both is an argparse error rather than a silent precedence rule.

## The guard runs before the work, not after it

The check inside `upload()` sits immediately before the first PUT, so reaching it costs a full fetch → style transfer → variant encode first. The failed run above generated all four variants and then threw them away — about 30s per collision.

`upload.assert_unpublished()` is the same check against the same key, hoisted ahead of the fetch. The one inside `upload()` **stays and remains authoritative** — it is what narrows the window for a concurrent generator — so `main.py` routes the rejection through one helper at either site, and a collision that only appears at upload time behaves identically to one caught early.

## Incidental fix

Hoisting the preflight meant hoisting `utc_today()` to the top of `main()`. That removes a latent bug: the run date was previously computed *after* style transfer, so a run straddling midnight UTC could check one date for existing keys and publish under another.

## Testing

`uvx ruff check .` clean, 260 tests pass, 16 new:

- `TestPreflight` — runs before the fetch, shares one date with the upload, skipped by `--overwrite` and by `--dry-run` (which has no R2 credentials to preflight with).
- `TestSkipIfPublished` — exit 0 on a preflight collision and on losing the upload race; exit 1 without the flag; a free date still publishes; both flags together is an error.
- `TestAssertUnpublishedPreflight` — same key and bucket as the upload guard, never writes, non-404 `ClientError` propagates rather than reading as "free to publish".

## Not covered here

On a skipped scheduled run the workflow's success notification still says "Generate workflow completed successfully" — true, but it does not distinguish a publish from a no-op. Wiring that through would need `main.py` to report its outcome back to Actions; left out deliberately. `NTFY_TOPIC` is currently unset on the repo, so no notification fires either way today.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7KKRS4nL3X6JiHTX2mC9f)_